### PR TITLE
Fix typo in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     - name: bulid_and_push
       run: |
         dotnet_args="-c Release -p:NoPackageAnalysis=true"
-        if [[ ! "$GITHUB_REF" =~ ^/refs/tags/* ]]; then
+        if [[ ! "$GITHUB_REF" =~ ^refs/tags/* ]]; then
           project_suffix=dev.${{ github.sha }}
           dotnet_args="$dotnet_args --version-suffix $project_suffix"
         fi


### PR DESCRIPTION
The build workflow hadn't worked as well on tag pushed.
In my thought, it's because `GITHUB_REF` format is like `refs/tags/0.1.0`,  not `/refs/tags/0.1.0`.
So I fixed it.