### PR TITLE
IValue.Inspection: JSON-like human-readable representation

### DIFF
--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using Bencodex.Types;
 using Xunit;
 
@@ -288,6 +289,44 @@ namespace Bencodex.Tests.Types
                 () => dictionary.GetValue<Binary>(listKey));
             Assert.Throws<InvalidCastException>(
                 () => dictionary.GetValue<Text>(listKey));
+        }
+
+        [Fact]
+        public void Inspection()
+        {
+            Assert.Equal("{}", Dictionary.Empty.Inspection);
+
+            var one = Dictionary.Empty.SetItem("foo", "bar");
+            Assert.Equal(
+                "{\n  \"foo\": \"bar\"\n}",
+                one.Inspection
+            );
+            Assert.Equal(
+                "{\n  b\"\\x66\\x6f\\x6f\": \"bar\"\n}",
+                Dictionary.Empty.SetItem(Encoding.ASCII.GetBytes("foo"), "bar").Inspection
+            );
+            Assert.Equal(
+                @"{
+  ""baz"": {
+    ""foo"": ""bar""
+  },
+  ""foo"": ""bar""
+}",
+                one.SetItem("baz", one).Inspection
+            );
+        }
+
+        [Fact]
+        public void String()
+        {
+            Assert.Equal(
+                "Bencodex.Types.Dictionary {}",
+                Dictionary.Empty.ToString()
+            );
+            Assert.Equal(
+                "Bencodex.Types.Dictionary {\n  \"foo\": \"bar\"\n}",
+                Dictionary.Empty.SetItem("foo", "bar").ToString()
+            );
         }
     }
 }

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+using Bencodex.Types;
+using Xunit;
+
+namespace Bencodex.Tests.Types
+{
+    public class ListTest
+    {
+        private static List _zero;
+        private static List _one;
+        private static List _two;
+        private static List _nest;
+
+        static ListTest()
+        {
+            _zero = default(List);
+            _one = new List(new IValue[] { default(Null) });
+            _two = new List(new Text[] { "hello", "world" }.Cast<IValue>());
+            _nest = new List(
+                new IValue[]
+                {
+                    default(Null),
+                    _zero,
+                    _one,
+                    _two,
+                }
+            );
+        }
+
+        [Fact]
+        public void Inspect()
+        {
+            Assert.Equal("[]", _zero.Inspection);
+            Assert.Equal("[null]", _one.Inspection);
+            Assert.Equal("[\n  \"hello\",\n  \"world\"\n]", _two.Inspection);
+
+            var expected = @"[
+  null,
+  [],
+  [null],
+  [
+    ""hello"",
+    ""world""
+  ]
+]";
+            Assert.Equal(expected, _nest.Inspection);
+
+            // If any element is a list/dict it should be indented
+            Assert.Equal("[\n  []\n]", new List(new IValue[] { _zero }).Inspection);
+            Assert.Equal("[\n  {}\n]", new List(new IValue[] { Dictionary.Empty }).Inspection);
+        }
+
+        [Fact]
+        public void String()
+        {
+            Assert.Equal("Bencodex.Types.List []", _zero.ToString());
+            Assert.Equal("Bencodex.Types.List [null]", _one.ToString());
+            Assert.Equal(
+                "Bencodex.Types.List [\n  \"hello\",\n  \"world\"\n]",
+                _two.ToString()
+            );
+        }
+    }
+}

--- a/Bencodex.Tests/Types/ValueTests.cs
+++ b/Bencodex.Tests/Types/ValueTests.cs
@@ -27,19 +27,29 @@ namespace Bencodex.Tests.Types
                 new byte[] { 0x6e },  // "n"
                 _codec.Encode(default(Null))
             );
+
+            Assert.Equal("null", default(Null).Inspection);
+            Assert.Equal("Bencodex.Types.Null", default(Null).ToString());
         }
 
         [Fact]
         public void Boolean()
         {
+            var t = new Bencodex.Types.Boolean(true);
+            var f = new Bencodex.Types.Boolean(false);
             AssertEqual(
                 new byte[] { 0x74 },  // "t"
-                _codec.Encode(new Bencodex.Types.Boolean(true))
+                _codec.Encode(t)
             );
             AssertEqual(
                 new byte[] { 0x66 },  // "f"
-                _codec.Encode(new Bencodex.Types.Boolean(false))
+                _codec.Encode(f)
             );
+
+            Assert.Equal("true", t.Inspection);
+            Assert.Equal("false", f.Inspection);
+            Assert.Equal("Bencodex.Types.Boolean true", t.ToString());
+            Assert.Equal("Bencodex.Types.Boolean false", f.ToString());
         }
 
         [Fact]
@@ -59,29 +69,46 @@ namespace Bencodex.Tests.Types
             );
             IntegerGeneric(i => new Integer(new BigInteger(i)));
             IntegerGeneric(i => new Integer(i.ToString()));
+
+            Assert.Equal("123", new Integer(123).Inspection);
+            Assert.Equal("-456", new Integer(-456).Inspection);
+            Assert.Equal("Bencodex.Types.Integer 123", new Integer(123).ToString());
+            Assert.Equal("Bencodex.Types.Integer -456", new Integer(-456).ToString());
         }
 
         [Fact]
-        public void ByteString()
+        public void Binary()
         {
+            var empty = default(Binary);
+            var hello = new Binary(new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f });
+
             AssertEqual(
                 new byte[] { 0x30, 0x3a },  // "0:"
-                _codec.Encode(default(Binary))
+                _codec.Encode(empty)
             );
             AssertEqual(
                 new byte[] { 0x35, 0x3a, 0x68, 0x65, 0x6c, 0x6c, 0x6f },
-                _codec.Encode( // "5:hello"
-                    new Binary(new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f }) // "hello"
-                )
+                _codec.Encode(hello) // "5:hello"
+            );
+
+            Assert.Equal("b\"\"", empty.Inspection);
+            Assert.Equal(@"b""\x68\x65\x6c\x6c\x6f""", hello.Inspection);
+            Assert.Equal("Bencodex.Types.Binary b\"\"", empty.ToString());
+            Assert.Equal(
+                @"Bencodex.Types.Binary b""\x68\x65\x6c\x6c\x6f""",
+                hello.ToString()
             );
         }
 
         [Fact]
         public void UnicodeText()
         {
+            var empty = default(Text);
+            var nihao = new Text("\u4f60\u597d");
+
             AssertEqual(
                 new byte[] { 0x75, 0x30, 0x3a },  // "u0:"
-                _codec.Encode(default(Text))
+                _codec.Encode(empty)
             );
             AssertEqual(
                 new byte[]
@@ -91,16 +118,30 @@ namespace Bencodex.Tests.Types
 
                     // "u6:\xe4\xbd\xa0\xe5\xa5\xbd"
                 },
-                _codec.Encode(new Text("\u4f60\u597d")) // "你好"
+                _codec.Encode(nihao) // "你好"
             );
+
+            var complex = new Text("new lines and\n\"quotes\" become escaped to \\");
+
+            Assert.Equal("\"\"", empty.Inspection);
+            Assert.Equal("\"\u4f60\u597d\"", nihao.Inspection);
+            Assert.Equal(
+                "\"new lines and\\n\\\"quotes\\\" become escaped to \\\\\"",
+                complex.Inspection
+            );
+            Assert.Equal("Bencodex.Types.Text \"\"", empty.ToString());
+            Assert.Equal("Bencodex.Types.Text \"\u4f60\u597d\"", nihao.ToString());
         }
 
         [Fact]
         public void List()
         {
+            var zero = default(List);
+            var two = new List(new Text[] { "hello", "world" }.Cast<IValue>());
+
             AssertEqual(
                 new byte[] { 0x6c, 0x65 },  // "le"
-                _codec.Encode(default(List))
+                _codec.Encode(zero)
             );
             AssertEqual(
                 new byte[] { 0x6c, 0x65 },  // "le"
@@ -118,9 +159,7 @@ namespace Bencodex.Tests.Types
 
                     // "lu5:hellou5:worlde"
                 },
-                _codec.Encode(
-                    new List(new Text[] { "hello", "world" }.Cast<IValue>())
-                )
+                _codec.Encode(two)
             );
         }
 

--- a/Bencodex/Types/Binary.cs
+++ b/Bencodex/Types/Binary.cs
@@ -32,6 +32,16 @@ namespace Bencodex.Types
 
         public byte[] Value => _value ?? (_value = new byte[0]);
 
+        [Pure]
+        public string Inspection
+        {
+            get
+            {
+                IEnumerable<string> contents = this.Select(b => $"\\x{b:x2}");
+                return $"b\"{string.Join(string.Empty, contents)}\"";
+            }
+        }
+
         public static implicit operator Binary(byte[] bytes)
         {
             return new Binary(bytes);
@@ -142,9 +152,7 @@ namespace Bencodex.Types
         }
 
         [Pure]
-        public override string ToString()
-        {
-            return BitConverter.ToString(Value).Replace("-", string.Empty).ToLower();
-        }
+        public override string ToString() =>
+            $"{nameof(Bencodex)}.{nameof(Bencodex.Types)}.{nameof(Binary)} {Inspection}";
     }
 }

--- a/Bencodex/Types/Boolean.cs
+++ b/Bencodex/Types/Boolean.cs
@@ -21,6 +21,10 @@ namespace Bencodex.Types
 
         public bool Value { get; }
 
+        [Pure]
+        public string Inspection =>
+            Value ? "true" : "false";
+
         public static implicit operator bool(Boolean boolean)
         {
             return boolean.Value;
@@ -90,5 +94,9 @@ namespace Bencodex.Types
                 yield return new byte[1] { 0x66 };  // 'f'
             }
         }
+
+        [Pure]
+        public override string ToString() =>
+            $"{nameof(Bencodex)}.{nameof(Bencodex.Types)}.{nameof(Boolean)} {Inspection}";
     }
 }

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -37,6 +37,24 @@ namespace Bencodex.Types
 
         public IEnumerable<IValue> Values => Value.Values;
 
+        [Pure]
+        public string Inspection
+        {
+            get
+            {
+                if (!this.Any())
+                {
+                    return "{}";
+                }
+
+                IEnumerable<string> pairs = this.Select(kv =>
+                    $"{kv.Key.Inspection}: {kv.Value.Inspection.Replace("\n", "\n  ")}"
+                ).OrderBy(s => s);
+                string pairsString = string.Join(",\n  ", pairs);
+                return $"{{\n  {pairsString}\n}}";
+            }
+        }
+
         private ImmutableDictionary<IKey, IValue> Value =>
             _value ?? (_value = ImmutableDictionary<IKey, IValue>.Empty);
 
@@ -445,13 +463,7 @@ namespace Bencodex.Types
         }
 
         [Pure]
-        public override string ToString()
-        {
-            IEnumerable<string> pairs = this.Select(
-                kv => $"{kv.Key}: {kv.Value}"
-            );
-            string pairsString = string.Join(", ", pairs);
-            return $"{{{pairsString}}}";
-        }
+        public override string ToString() =>
+            $"{nameof(Bencodex)}.{nameof(Bencodex.Types)}.{nameof(Dictionary)} {Inspection}";
     }
 }

--- a/Bencodex/Types/IValue.cs
+++ b/Bencodex/Types/IValue.cs
@@ -14,6 +14,12 @@ namespace Bencodex.Types
     /// <seealso cref="Dictionary"/>
     public interface IValue
     {
+        /// <summary>A JSON-like human-readable representation for
+        /// debugging.</summary>
+        /// <returns>A JSON-like representation.</returns>
+        [Pure]
+        string Inspection { get; }
+
         /// <summary>Encodes the value into <c cref="byte">Byte</c>
         /// arrays.</summary>
         /// <returns><c cref="byte">Byte</c> arrays of Bencodex

--- a/Bencodex/Types/Integer.cs
+++ b/Bencodex/Types/Integer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.Globalization;
 using System.Numerics;
 using System.Text;
 
@@ -55,6 +56,10 @@ namespace Bencodex.Types
         }
 
         public BigInteger Value { get; }
+
+        [Pure]
+        public string Inspection =>
+            Value.ToString(CultureInfo.InvariantCulture);
 
         public static implicit operator BigInteger(Integer i)
         {
@@ -214,9 +219,8 @@ namespace Bencodex.Types
             yield return new byte[1] { 0x65 };  // 'e'
         }
 
-        public override string ToString()
-        {
-            return Value.ToString();
-        }
+        [Pure]
+        public override string ToString() =>
+            $"{nameof(Bencodex)}.{nameof(Bencodex.Types)}.{nameof(Integer)} {Inspection}";
     }
 }

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -22,6 +22,34 @@ namespace Bencodex.Types
         public ImmutableArray<IValue> Value =>
             _value.IsDefault ? (_value = ImmutableArray<IValue>.Empty) : _value;
 
+        [Pure]
+        public string Inspection
+        {
+            get
+            {
+                switch (Value.Length)
+                {
+                    case 0:
+                        return "[]";
+
+                    case 1:
+                        var el = this.First();
+                        if (el is List || el is Dictionary)
+                        {
+                            goto default;
+                        }
+
+                        return $"[{el.Inspection}]";
+
+                    default:
+                        IEnumerable<string> elements = this.Select(v =>
+                            v.Inspection.Replace("\n", "\n  ")
+                        );
+                        return $"[\n  {string.Join(",\n  ", elements)}\n]";
+                }
+            }
+        }
+
         int IReadOnlyCollection<IValue>.Count => Value.Length;
 
         IValue IReadOnlyList<IValue>.this[int index] => Value[index];
@@ -186,11 +214,7 @@ namespace Bencodex.Types
         }
 
         [Pure]
-        public override string ToString()
-        {
-            IEnumerable<string> elements = this.Select(v => v.ToString());
-            string elementsString = string.Join(", ", elements);
-            return $"[{elementsString}]";
-        }
+        public override string ToString() =>
+            $"{nameof(Bencodex)}.{nameof(Bencodex.Types)}.{nameof(List)} {Inspection}";
     }
 }

--- a/Bencodex/Types/Null.cs
+++ b/Bencodex/Types/Null.cs
@@ -11,6 +11,9 @@ namespace Bencodex.Types
         IComparable<Null>,
         IComparable
     {
+        [Pure]
+        public string Inspection => $"null";
+
         public override int GetHashCode() => 0;
 
         int IComparable.CompareTo(object obj) => obj is Null ? 0 : -1;
@@ -29,5 +32,9 @@ namespace Bencodex.Types
         {
             yield return new byte[1] { 0x6e }; // 'n'
         }
+
+        [Pure]
+        public override string ToString() =>
+            $"{nameof(Bencodex)}.{nameof(Bencodex.Types)}.{nameof(Null)}";
     }
 }

--- a/Bencodex/Types/Text.cs
+++ b/Bencodex/Types/Text.cs
@@ -25,6 +25,19 @@ namespace Bencodex.Types
         [Pure]
         byte? IKey.KeyPrefix => 0x75;  // 'u'
 
+        [Pure]
+        public string Inspection
+        {
+            get
+            {
+                string contents = Value
+                    .Replace("\\", "\\\\")
+                    .Replace("\n", "\\n")
+                    .Replace("\"", "\\\"");
+                return $"\"{contents}\"";
+            }
+        }
+
         public static implicit operator string(Text t)
         {
             return t.Value;
@@ -117,9 +130,8 @@ namespace Bencodex.Types
             }
         }
 
-        public override string ToString()
-        {
-            return Value;
-        }
+        [Pure]
+        public override string ToString() =>
+            $"{nameof(Bencodex)}.{nameof(Bencodex.Types)}.{nameof(Text)} {Inspection}";
     }
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,8 +6,7 @@ Version 0.3.0
 
 To be released.
 
- -  `Bencodex.Types.Dictionary.SetItem()` became
-    to have more overloads.  [[#7]]
+ -  `Bencodex.Types.Dictionary.SetItem()` became to have more overloads.  [[#7]]
      -  Added overloads, which is listed below,
         return `Bencodex.Types.Dictionary` instead of
         `IImmutableDictionary<IKey, IValue>`. Note that existing
@@ -56,8 +55,15 @@ To be released.
  -  Added `Bencodex.Types.Dictionary[string]` indexer. [[#7]]
  -  Added `Bencodex.Types.Dictionary[byte[]]` indexer. [[#7]]
  -  Added `Bencodex.Types.Dictionary.GetValue<T>(byte[])` method. [[#11]]
+ -  Added `IValue.Inspection` property to get a JSON-like human-readable
+    representation for the sake of debugging.  [[#12], [#13]]
+ -  `ToString()` method of `IValue` subclasses became to return its `Inspection`
+    with a prefix of the qualified class name.  [[#12], [#13]]
 
 [#7]: https://github.com/planetarium/bencodex.net/pull/7
+[#11]: https://github.com/planetarium/bencodex.net/pull/11
+[#12]: https://github.com/planetarium/bencodex.net/issues/12
+[#13]: https://github.com/planetarium/bencodex.net/pull/13
 
 
 Version 0.2.0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,10 @@ variables:
   buildConfiguration: Release
 
 steps:
+- script: git config --global core.autocrlf false
+  displayName: git config core.autocrlf false
+- checkout: self
+  fetchDepth: 10
 - script: git submodule update --init --recursive
   displayName: git submodule update --init --recursive
 - task: NuGetToolInstaller@0


### PR DESCRIPTION
This adds `Inspection` property to `IValue` in order to resolve #12.  This looks like JSON, and with no `Binary` values it's indeed virtually JSON, for `Binary` values it's printed as a string of hex-escaped bytes with `b` prefix; in other words, it's like Python's `repr()`.

For example, <https://github.com/planetarium/bencodex/blob/1.2/testsuite/mixed-dict.dat> is turned into:

```python
{
  "a": 1,
  "á": 2,
  "á": 5,
  "b": 3,
  "c": 4,
  b"\x61": 1,
  b"\x62": 2,
  b"\x63": 3
}
```

Another example, <https://github.com/planetarium/bencodex/blob/1.2/testsuite/list-of-dicts.dat>, becomes:

```python
[
  {
    "byte-string": true,
    "human-readable": false,
    "name": "bencode",
    "normalization": true,
    "schema": false,
    "unicode-text": false,
    "zero-copy": false
  },
  {
    "byte-string": true,
    "human-readable": false,
    "name": "bencodex",
    "normalization": true,
    "schema": false,
    "unicode-text": true,
    "zero-copy": false
  },
  {
    "byte-string": true,
    "human-readable": false,
    "name": "capnp",
    "normalization": false,
    "schema": true,
    "unicode-text": true,
    "zero-copy": true
  },
  {
    "byte-string": false,
    "human-readable": true,
    "name": "json",
    "normalization": false,
    "schema": false,
    "unicode-text": true,
    "zero-copy": false
  },
  {
    "byte-string": true,
    "human-readable": false,
    "name": "msgpack",
    "normalization": false,
    "schema": false,
    "unicode-text": true,
    "zero-copy": false
  },
  {
    "byte-string": true,
    "human-readable": false,
    "name": "thrift",
    "normalization": false,
    "schema": true,
    "unicode-text": true,
    "zero-copy": false
  },
  {
    "byte-string": true,
    "human-readable": true,
    "name": "yaml",
    "normalization": false,
    "unicode-text": true,
    "zero-copy": false
  }
]
```