### PR TITLE
Resolve explicit implementation issues on Bencodex.Types.List

### DIFF
--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -60,5 +60,13 @@ namespace Bencodex.Tests.Types
                 _two.ToString()
             );
         }
+
+        [Fact]
+        public void Indexer()
+        {
+            Assert.Equal(default(Null), _one[0]);
+            Assert.Equal((Text)"hello", _two[0]);
+            Assert.Equal((Text)"world", _two[1]);
+        }
     }
 }

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -68,5 +68,14 @@ namespace Bencodex.Tests.Types
             Assert.Equal((Text)"hello", _two[0]);
             Assert.Equal((Text)"world", _two[1]);
         }
+
+        [Fact]
+        public void Count()
+        {
+            // Compare with inner implementation, to avoid Xunit check.
+            Assert.Equal(_zero.Value.Length, _zero.Count);
+            Assert.Equal(_one.Value.Length, _one.Count);
+            Assert.Equal(_two.Value.Length, _two.Count);
+        }
     }
 }

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -54,6 +54,8 @@ namespace Bencodex.Types
 
         IValue IReadOnlyList<IValue>.this[int index] => Value[index];
 
+        public IValue this[int index] => Value[index];
+
         bool IEquatable<IImmutableList<IValue>>.Equals(
             IImmutableList<IValue> other
         )

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -50,7 +50,7 @@ namespace Bencodex.Types
             }
         }
 
-        int IReadOnlyCollection<IValue>.Count => Value.Length;
+        public int Count => Value.Length;
 
         public IValue this[int index] => Value[index];
 

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -52,8 +52,6 @@ namespace Bencodex.Types
 
         int IReadOnlyCollection<IValue>.Count => Value.Length;
 
-        IValue IReadOnlyList<IValue>.this[int index] => Value[index];
-
         public IValue this[int index] => Value[index];
 
         bool IEquatable<IImmutableList<IValue>>.Equals(

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -83,6 +83,7 @@ To be released.
     which is still compatible in source code level.  [[#23]]
  -  Fixed encoding and decoding bugs that had been occurred on some locales
     writing [RTL] scripts, e.g., Arabic (`ar`).  [[#23]]
+ -  Added `Bencodex.Types.List[int]` indexer.  [[#25]]
 
 [#7]: https://github.com/planetarium/bencodex.net/pull/7
 [#11]: https://github.com/planetarium/bencodex.net/pull/11
@@ -92,6 +93,7 @@ To be released.
 [#15]: https://github.com/planetarium/bencodex.net/pull/15
 [#23]: https://github.com/planetarium/bencodex.net/pull/23
 [#24]: https://github.com/planetarium/bencodex.net/pull/24
+[#25]: https://github.com/planetarium/bencodex.net/pull/25
 [nullable reference types]: https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references
 [RTL]: https://en.wikipedia.org/wiki/Right-to-left
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -84,6 +84,7 @@ To be released.
  -  Fixed encoding and decoding bugs that had been occurred on some locales
     writing [RTL] scripts, e.g., Arabic (`ar`).  [[#23]]
  -  Added `Bencodex.Types.List[int]` indexer.  [[#25]]
+ -  Added `Bencodex.Types.List.Count` property.  [[#25]]
 
 [#7]: https://github.com/planetarium/bencodex.net/pull/7
 [#11]: https://github.com/planetarium/bencodex.net/pull/11


### PR DESCRIPTION
Fixes that the below line was invalid with the message, *Cannot access explicit implementation of 'IReadOnlyList<IValue>.Item'*. 4af2ee6

```csharp
Bencodex.Types.List list = ...;
var item = list[0]; // ← this point
```

And also in `Bencodex.Types.List.Count`. 0857583