### PR TITLE
Introduce `Bencodex.Types.List.Add(...)` API

### DIFF
--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Text;
 using Bencodex.Types;
 using Xunit;
 
@@ -76,6 +77,25 @@ namespace Bencodex.Tests.Types
             Assert.Equal(_zero.Value.Length, _zero.Count);
             Assert.Equal(_one.Value.Length, _one.Count);
             Assert.Equal(_two.Value.Length, _two.Count);
+        }
+
+        [Fact]
+        public void Add()
+        {
+            var list = List.Empty
+                .Add("foo")
+                .Add(Encoding.UTF8.GetBytes("bar"))
+                .Add(0xbeef)
+                .Add(true)
+                .Add(List.Empty)
+                .Add(Dictionary.Empty);
+
+            Assert.Equal((Text)"foo", list[0]);
+            Assert.Equal((Binary)Encoding.UTF8.GetBytes("bar"), list[1]);
+            Assert.Equal((Integer)0xbeef, list[2]);
+            Assert.Equal((Boolean)true, list[3]);
+            Assert.Equal(List.Empty, list[4]);
+            Assert.Equal(Dictionary.Empty, list[5]);
         }
     }
 }

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Linq;
+using System.Numerics;
 
 namespace Bencodex.Types
 {
@@ -18,6 +19,8 @@ namespace Bencodex.Types
         {
             _value = value?.ToImmutableArray() ?? ImmutableArray<IValue>.Empty;
         }
+
+        public static List Empty => default(List);
 
         public ImmutableArray<IValue> Value =>
             _value.IsDefault ? (_value = ImmutableArray<IValue>.Empty) : _value;
@@ -90,9 +93,29 @@ namespace Bencodex.Types
             return ((IEnumerable)Value).GetEnumerator();
         }
 
-        IImmutableList<IValue> IImmutableList<IValue>.Add(IValue value)
+        public IImmutableList<IValue> Add(IValue value)
         {
             return new List(Value.Add(value));
+        }
+
+        public List Add(string value)
+        {
+            return new List(Value.Add((Text)value));
+        }
+
+        public List Add(bool value)
+        {
+            return new List(Value.Add((Boolean)value));
+        }
+
+        public List Add(BigInteger value)
+        {
+            return new List(Value.Add((Integer)value));
+        }
+
+        public List Add(byte[] value)
+        {
+            return new List(Value.Add((Binary)value));
         }
 
         IImmutableList<IValue> IImmutableList<IValue>.AddRange(

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -93,7 +93,12 @@ namespace Bencodex.Types
             return ((IEnumerable)Value).GetEnumerator();
         }
 
-        public IImmutableList<IValue> Add(IValue value)
+        IImmutableList<IValue> IImmutableList<IValue>.Add(IValue value)
+        {
+            return new List(Value.Add(value));
+        }
+
+        public List Add(IValue value)
         {
             return new List(Value.Add(value));
         }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,7 @@ To be released.
       -  (`byte[]`, `IEnumerable<IValue>`)
  -  Added `Bencodex.Types.Dictionary[string]` indexer. [[#7]]
  -  Added `Bencodex.Types.Dictionary[byte[]]` indexer. [[#7]]
+ -  Added `Bencodex.Types.Dictionary.Empty` static property.  [[#7]]
  -  Added `Bencodex.Types.Dictionary.GetValue<T>(byte[])` method. [[#11]]
  -  `Bencodex.Types.Dictionary.TryGetKey()` became to fill its `out` parameter
     with an empty `Binary` value when it returns `false`.  [[#24]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,17 +86,14 @@ To be released.
     writing [RTL] scripts, e.g., Arabic (`ar`).  [[#23]]
  -  Added `Bencodex.Types.List[int]` indexer.  [[#25]]
  -  Added `Bencodex.Types.List.Count` property.  [[#25]]
- -  `Bencodex.Types.List.Add()` became to have more overloads.  [[#26]]
-     -  Added overloads, which is listed below,
-        return `Bencodex.Types.List` instead of
-        `IImmutableList<IValue>`. Note that existing
-        `IImmutableList<IValue>.Add(IValue)` method which implements
-        `IImmutableList<IValue>` is still remained as it had been.
-     -  (`IValue`)
-     -  (`string`)
-     -  (`byte[]`)
-     -  (`bool`)
-     -  (`BigInteger`)
+ -  `Bencodex.Types.List.Add()` became to have more overloads,
+     which return `Bencodex.Types.List` so that it is convenient to chain
+     method calls.  [[#26]]
+     -  `Add(IValue)`
+     -  `Add(string)`
+     -  `Add(byte[])`
+     -  `Add(bool)`
+     -  `Add(BigInteger)`
  -  Added `Bencodex.Types.List.Empty` static property.  [[#26]]
 
 [#7]: https://github.com/planetarium/bencodex.net/pull/7

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,6 +85,17 @@ To be released.
     writing [RTL] scripts, e.g., Arabic (`ar`).  [[#23]]
  -  Added `Bencodex.Types.List[int]` indexer.  [[#25]]
  -  Added `Bencodex.Types.List.Count` property.  [[#25]]
+ -  `Bencodex.Types.List.Add()` became to have more overloads.  [[#26]]
+     -  Added overloads, which is listed below,
+        return `Bencodex.Types.List` instead of
+        `IImmutableList<IValue>`. Note that existing
+        `Add(IValue)` method which implements
+        `IImmutableList<IValue>` is still remained as it had been.
+     -  (`string`)
+     -  (`byte[]`)
+     -  (`bool`)
+     -  (`BigInteger`)
+ -  Added `Bencodex.Types.List.Empty` static property.  [[#26]]
 
 [#7]: https://github.com/planetarium/bencodex.net/pull/7
 [#11]: https://github.com/planetarium/bencodex.net/pull/11
@@ -95,6 +106,7 @@ To be released.
 [#23]: https://github.com/planetarium/bencodex.net/pull/23
 [#24]: https://github.com/planetarium/bencodex.net/pull/24
 [#25]: https://github.com/planetarium/bencodex.net/pull/25
+[#26]: https://github.com/planetarium/bencodex.net/pull/26
 [nullable reference types]: https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references
 [RTL]: https://en.wikipedia.org/wiki/Right-to-left
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,8 +90,9 @@ To be released.
      -  Added overloads, which is listed below,
         return `Bencodex.Types.List` instead of
         `IImmutableList<IValue>`. Note that existing
-        `Add(IValue)` method which implements
+        `IImmutableList<IValue>.Add(IValue)` method which implements
         `IImmutableList<IValue>` is still remained as it had been.
+     -  (`IValue`)
      -  (`string`)
      -  (`byte[]`)
      -  (`bool`)


### PR DESCRIPTION
It contains overloads below:

 - `Bencodex.Types.List.Add(IValue)`
 - `Bencodex.Types.List.Add(bool)`
 - `Bencodex.Types.List.Add(string)`
 - `Bencodex.Types.List.Add(byte[])`
 - `Bencodex.Types.List.Add(BigInteger)`

