### PR TITLE
Codec benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 .vs/
 .vscode/
 bin/
+BenchmarkDotNet.Artifacts/
 obj/

--- a/Bencodex.Benchmarks/Bencodex.Benchmarks.csproj
+++ b/Bencodex.Benchmarks/Bencodex.Benchmarks.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="ByteSize" Version="2.0.0" />
+    <PackageReference
+      Include="BenchmarkDotNet.Diagnostics.Windows"
+      Version="0.12.1"
+      Condition=" '$(OS)' == 'Windows_NT' " />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Bencodex\Bencodex.csproj" />
+  </ItemGroup>
+</Project>

--- a/Bencodex.Benchmarks/Bencodex.Benchmarks.csproj
+++ b/Bencodex.Benchmarks/Bencodex.Benchmarks.csproj
@@ -2,6 +2,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <NoWarn>true</NoWarn>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 

--- a/Bencodex.Benchmarks/CodecBenchmark.cs
+++ b/Bencodex.Benchmarks/CodecBenchmark.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using Bencodex.Types;
+using ByteSizeLib;
+
+namespace Bencodex.Benchmarks
+{
+    public class CodecBenchmark
+    {
+        [ParamsSource(nameof(DataFiles))]
+        public string DataFile { get; set; }
+
+        public IValue Value { get; private set; } = new Null();
+
+        public byte[] Bytes { get; private set; } = new byte[0];
+
+        public Stream Stream { get; private set; } = Stream.Null;
+
+        [GlobalSetup]
+        public void LoadData()
+        {
+            using var f = File.OpenRead(DataFile);
+            using var reader = new BinaryReader(f);
+            Bytes = reader.ReadBytes((int)f.Length);
+            Stream = new MemoryStream(Bytes);
+            Value = Codec.Decode(Bytes);
+        }
+
+        [GlobalCleanup]
+        public void CloseStream()
+        {
+            try
+            {
+                Stream?.Close();
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        [IterationSetup]
+        public void ResetStream()
+        {
+            try
+            {
+                Stream?.Seek(0, SeekOrigin.Begin);
+            }
+            catch (Exception)
+            {
+            }
+        }
+
+        [Benchmark]
+        public void EncodeIntoBytes()
+        {
+            byte[] _ = Codec.Encode(Value);
+        }
+
+        [Benchmark]
+        public void EncodeIntoStream()
+        {
+            Codec.Encode(Value, new MemoryStream());
+        }
+
+        [Benchmark]
+        public void DecodeFromBytes()
+        {
+            IValue _ = Codec.Decode(Bytes);
+        }
+
+        [Benchmark]
+        public void DecodeFromStream()
+        {
+            IValue _ = Codec.Decode(Stream);
+        }
+
+        public static Codec Codec = new Codec();
+
+        public static string[] DataFiles { get; set; } = new string[0];
+
+        public static void Main(string[] args)
+        {
+            const string envVarName = "BENCODEX_BENCHMARKS_DATA_DIR";
+            string dirPath =
+                Environment.GetEnvironmentVariable(envVarName) ?? ".";
+            Console.Error.WriteLine("Look up Bencodex benchmark data files in {0}...", dirPath);
+            Console.Error.WriteLine("(You can configure the directory to look up by setting {0}.)",
+                                    envVarName);
+            string[] files;
+            if (Directory.Exists(dirPath))
+            {
+                files = Directory.EnumerateFiles(dirPath, "*.dat", SearchOption.AllDirectories)
+                    .Select(Path.GetFullPath)
+                    .ToArray();
+            }
+            else
+            {
+                files = new string[] { Path.GetFullPath(dirPath) };
+            }
+
+            int count = 0;
+            long size = 0;
+            foreach (string file in files)
+            {
+                var fileInfo = new FileInfo(file);
+                size += fileInfo.Length;
+                Console.Error.WriteLine("{0}", file);
+                count++;
+            }
+
+            ByteSize byteSize = ByteSize.FromBytes(size);
+            Console.Error.WriteLine(
+                "Loading {0} files ({1} = {2} bytes)...", count, byteSize, size);
+            DataFiles = files;
+
+            BenchmarkSwitcher.FromAssembly(typeof(CodecBenchmark).Assembly).Run(args);
+        }
+    }
+}

--- a/Bencodex.sln
+++ b/Bencodex.sln
@@ -1,8 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
+# 
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bencodex", "Bencodex\Bencodex.csproj", "{2E0DBCAE-A203-429D-A36F-D5F4583278DC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bencodex.Tests", "Bencodex.Tests\Bencodex.Tests.csproj", "{D0EEFE59-8703-4527-A865-A596EBE672A9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bencodex.Benchmarks", "Bencodex.Benchmarks\Bencodex.Benchmarks.csproj", "{FD5C06D6-A616-4560-9E15-C8938EDC724B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -18,5 +21,9 @@ Global
 		{D0EEFE59-8703-4527-A865-A596EBE672A9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D0EEFE59-8703-4527-A865-A596EBE672A9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D0EEFE59-8703-4527-A865-A596EBE672A9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD5C06D6-A616-4560-9E15-C8938EDC724B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD5C06D6-A616-4560-9E15-C8938EDC724B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD5C06D6-A616-4560-9E15-C8938EDC724B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD5C06D6-A616-4560-9E15-C8938EDC724B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
You can conduct a benchmark in short through the following command:

```
dotnet run -c Release -p Bencodex.Benchmarks -- -j dry -i -f CodecBenchmark --iterationCount 1
```

In order to run it properly:

```
dotnet run -c Release -p Bencodex.Benchmarks -- -i -f CodecBenchmark
```

If you need to profile it using [`EventPipeProfiler`](https://benchmarkdotnet.org/articles/features/event-pipe-profiler.html):

```
dotnet run -c Release -p Bencodex.Benchmarks -- -j dry -i -f CodecBenchmark --iterationCount 1 -p EP
```

---

You can configure the custom data set using the `BENCODEX_BENCHMARKS_DATA_DIR` environment variable.

```bash
export BENCODEX_BENCHMARKS_DATA_DIR=$HOME/my-bencodex-data/
dotnet run -c Release -p Bencodex.Benchmarks -- -j dry -i -f CodecBenchmark --iterationCount 1
```

**Note that the data files should end with the *.dat* suffix.**

---

If you want to rather use your favorite profiler, BenchmarkDotNet may not be handy.  In order to avoid BenchmarkDotNet which is quite complex, use the simple mode.  You can turn on the simple mode by configuring the environment variable `BENCODEX_BENCHMARKS_SIMPLE=true`.  This samples only the heaviest 50 files in the specified directory (the CWD if unspecified).

```bash
export BENCODEX_BENCHMARKS_SIMPLE=true
export BENCODEX_BENCHMARKS_DATA_DIR=$HOME/my-bencodex-data/
dotnet run -c Release -p Bencodex.Benchmarks
```