### PR TITLE
Add EncodeToStream

### DIFF
--- a/Bencodex/Codec.cs
+++ b/Bencodex/Codec.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Diagnostics.Contracts;
 using System.IO;
-using Bencodex.Misc;
 using Bencodex.Types;
 
 namespace Bencodex
@@ -44,10 +43,7 @@ namespace Bencodex
                 );
             }
 
-            foreach (byte[] chunk in value.EncodeIntoChunks())
-            {
-                output.Write(chunk, 0, chunk.Length);
-            }
+            value.EncodeToStream(output);
         }
 
         /// <summary>Decodes an encoded value from an <paramref name="input"/>

--- a/Bencodex/Types/Binary.cs
+++ b/Bencodex/Types/Binary.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Text;
 using Bencodex.Misc;
@@ -195,6 +196,16 @@ namespace Bencodex.Types
             yield return Encoding.ASCII.GetBytes(len);
             yield return CommonVariables.Separator;  // ':'
             yield return ((IKey)this).EncodeAsByteArray();
+        }
+
+        public void EncodeToStream(Stream stream)
+        {
+            byte[] value = _value ?? new byte[0];
+            string len = value.Length.ToString(CultureInfo.InvariantCulture);
+            byte[] lenBytes = Encoding.ASCII.GetBytes(len);
+            stream.Write(lenBytes, 0, lenBytes.Length);
+            stream.WriteByte(CommonVariables.Separator[0]);
+            stream.Write(value, 0, value.Length);
         }
 
         [Pure]

--- a/Bencodex/Types/Boolean.cs
+++ b/Bencodex/Types/Boolean.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.IO;
 
 namespace Bencodex.Types
 {
@@ -97,6 +98,12 @@ namespace Bencodex.Types
             {
                 yield return _false;
             }
+        }
+
+        public void EncodeToStream(Stream stream)
+        {
+            var value = Value ? _true[0] : _false[0];
+            stream.WriteByte(value);
         }
 
         [Pure]

--- a/Bencodex/Types/IValue.cs
+++ b/Bencodex/Types/IValue.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.IO;
 
 namespace Bencodex.Types
 {
@@ -28,5 +29,13 @@ namespace Bencodex.Types
         /// <seealso cref="Codec.Encode(IValue, System.IO.Stream)"/>
         [Pure]
         IEnumerable<byte[]> EncodeIntoChunks();
+
+        /// <summary>Writes the encoded value into <paramref name="stream"/>.
+        /// </summary>
+        /// <param name="stream">A stream to write the encoded value.</param>
+        /// <seealso cref="Codec.Encode(IValue)"/>
+        /// <seealso cref="Codec.Encode(IValue, System.IO.Stream)"/>
+        /// <seealso cref="EncodeIntoChunks"/>
+        void EncodeToStream(Stream stream);
     }
 }

--- a/Bencodex/Types/Integer.cs
+++ b/Bencodex/Types/Integer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Globalization;
+using System.IO;
 using System.Numerics;
 using System.Text;
 
@@ -220,6 +221,15 @@ namespace Bencodex.Types
             string digits = Value.ToString(CultureInfo.InvariantCulture);
             yield return Encoding.ASCII.GetBytes(digits);
             yield return CommonVariables.Suffix;
+        }
+
+        public void EncodeToStream(Stream stream)
+        {
+            stream.WriteByte(_prefix[0]);
+            string digits = Value.ToString(CultureInfo.InvariantCulture);
+            byte[] digitsAscii = Encoding.ASCII.GetBytes(digits);
+            stream.Write(digitsAscii, 0, digitsAscii.Length);
+            stream.WriteByte(CommonVariables.Suffix[0]);
         }
 
         [Pure]

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
+using System.IO;
 using System.Linq;
 using System.Numerics;
 
@@ -241,6 +242,17 @@ namespace Bencodex.Types
             }
 
             yield return CommonVariables.Suffix;
+        }
+
+        public void EncodeToStream(Stream stream)
+        {
+            stream.WriteByte(_listPrefix[0]);
+            foreach (IValue element in Value)
+            {
+                element.EncodeToStream(stream);
+            }
+
+            stream.WriteByte(CommonVariables.Suffix[0]);
         }
 
         [Pure]

--- a/Bencodex/Types/Null.cs
+++ b/Bencodex/Types/Null.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
+using System.IO;
 
 namespace Bencodex.Types
 {
@@ -31,6 +32,11 @@ namespace Bencodex.Types
         public IEnumerable<byte[]> EncodeIntoChunks()
         {
             yield return new byte[1] { 0x6e }; // 'n'
+        }
+
+        public void EncodeToStream(Stream stream)
+        {
+            stream.WriteByte(0x6e); // 'n'
         }
 
         [Pure]

--- a/Bencodex/Types/Text.cs
+++ b/Bencodex/Types/Text.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Globalization;
+using System.IO;
 using System.Text;
 
 namespace Bencodex.Types
@@ -130,6 +131,17 @@ namespace Bencodex.Types
             yield return Encoding.ASCII.GetBytes(len);
             yield return CommonVariables.Separator;
             yield return utf8;
+        }
+
+        public void EncodeToStream(Stream stream)
+        {
+            stream.WriteByte(_keyPrefix);
+            byte[] utf8 = ((IKey)this).EncodeAsByteArray();
+            string len = utf8.Length.ToString(CultureInfo.InvariantCulture);
+            byte[] lenBytes = Encoding.ASCII.GetBytes(len);
+            stream.Write(lenBytes, 0, lenBytes.Length);
+            stream.WriteByte(CommonVariables.Separator[0]);
+            stream.Write(utf8, 0, utf8.Length);
         }
 
         [Pure]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -101,10 +101,11 @@ To be released.
  -  Optimized `Bencodex.Types.Binary.GetHashCode()` method. Now the hash code is
     calculated using the modified [FNV], and cached after it is once calculated.
     [[#28]]
+ -  Added `IValue.EncodeToStream(Stream)` method.  [[#32]]
  -  `Bencodex.Types.Dictionary` became not to immediately realize the inner
     hash table, but do it when it needs (e.g., when to look up a key) instead.
     Note that this change does not cause any API changes, but just purposes
-    faster instantiation.  [[#32]]
+    faster instantiation.  [[#33]]
 
 [#7]: https://github.com/planetarium/bencodex.net/pull/7
 [#11]: https://github.com/planetarium/bencodex.net/pull/11
@@ -118,6 +119,7 @@ To be released.
 [#26]: https://github.com/planetarium/bencodex.net/pull/26
 [#28]: https://github.com/planetarium/bencodex.net/pull/28
 [#32]: https://github.com/planetarium/bencodex.net/pull/32
+[#33]: https://github.com/planetarium/bencodex.net/pull/33
 [nullable reference types]: https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references
 [RTL]: https://en.wikipedia.org/wiki/Right-to-left
 [FNV]: https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function


### PR DESCRIPTION
This adds `IValue.EncodeToStream(Stream)` method and uses it to reduce the encoding time.

---

Before:
```
Loading 50 files (102.26 MB = 102257499 bytes)...
Loaded 50 files.
Loading 00:00:00.0729370
Codec   00:00:18.4429740
Total   00:00:18.5159110
```

After:
```
Loading 50 files (102.26 MB = 102257499 bytes)...
Loaded 50 files.
Loading 00:00:00.0775620
Codec   00:00:15.8652380
Total   00:00:15.9428000
```