### PR TITLE
Delay dictionary realization when it's enumerated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -105,7 +105,7 @@ To be released.
  -  `Bencodex.Types.Dictionary` became not to immediately realize the inner
     hash table, but do it when it needs (e.g., when to look up a key) instead.
     Note that this change does not cause any API changes, but just purposes
-    faster instantiation.  [[#33]]
+    faster instantiation.  [[#33], [#34]]
 
 [#7]: https://github.com/planetarium/bencodex.net/pull/7
 [#11]: https://github.com/planetarium/bencodex.net/pull/11
@@ -120,6 +120,7 @@ To be released.
 [#28]: https://github.com/planetarium/bencodex.net/pull/28
 [#32]: https://github.com/planetarium/bencodex.net/pull/32
 [#33]: https://github.com/planetarium/bencodex.net/pull/33
+[#34]: https://github.com/planetarium/bencodex.net/pull/34
 [nullable reference types]: https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references
 [RTL]: https://en.wikipedia.org/wiki/Right-to-left
 [FNV]: https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function


### PR DESCRIPTION
Continued from #34.  This make latency short when a `Dictionary` having unrealized internal pairs is enumerated.  The solution is to delay its realization and just enumerate its internal key–value pairs.  One trick here I used to avoid key duplication (note that unrealized keys don't guarantee their uniqueness) is simply comparing with the key from the previous iteration.  This trick works because the enumeration is done after keys are sorted first.

Before:

```
Loading 50 files (102.26 MB = 102257499 bytes)...
Loaded 50 files.
Loading	00:00:00.1598300
Codec	00:00:15.4054540
Total	00:00:15.5652840
```

After:

```
Loading 50 files (102.26 MB = 102257499 bytes)...
Loaded 50 files.
Loading	00:00:00.1722320
Codec	00:00:08.1198900
Total	00:00:08.2921220
```