### PR TITLE
Fix decode

### DIFF
--- a/Bencodex/Decoder.cs
+++ b/Bencodex/Decoder.cs
@@ -193,8 +193,15 @@ namespace Bencodex
                 return _lastRead;
             }
 
-            byte[] buffer = Read(TinyBuffer);
-            return buffer.Length > 0 ? buffer[0] : (byte?)null;
+            int read = _stream.Read(TinyBuffer, 0, 1);
+            if (read > 0)
+            {
+                _lastRead = TinyBuffer[0];
+            }
+
+            _offset++;
+            _didBack = false;
+            return read == 0 ? (byte?)null : TinyBuffer[0];
         }
 
         private void Back()

--- a/Bencodex/Decoder.cs
+++ b/Bencodex/Decoder.cs
@@ -294,12 +294,6 @@ namespace Bencodex
             return buffer;
         }
 
-        private T ReadDigits<T>(bool takeMinusSign, byte delimiter, Func<byte[], T> converter)
-        {
-            byte[] digits = ReadDigits(takeMinusSign, delimiter);
-            return converter(digits);
-        }
-
         private T ReadDigits<T>(
             bool takeMinusSign,
             byte delimiter,
@@ -319,7 +313,8 @@ namespace Bencodex
         private (byte[] byteArray, int offsetAfterColon) ReadByteArray()
         {
             const byte colon = 0x3a;  // ':'
-            int length = ReadDigits(false, colon, Atoi);
+            byte[] digits = ReadDigits(false, colon);
+            int length = Atoi(digits);
             if (length < 1)
             {
                 return (new byte[0], _offset);

--- a/Bencodex/Decoder.cs
+++ b/Bencodex/Decoder.cs
@@ -10,6 +10,7 @@ namespace Bencodex
 {
     internal sealed class Decoder
     {
+        private static readonly byte[] TinyBuffer = new byte[1];
         private readonly Stream _stream;
         private byte _lastRead;
         private bool _didBack;
@@ -157,9 +158,9 @@ namespace Bencodex
             }
         }
 
-        private byte[] Read(int length)
+        private byte[] Read(byte[] buffer)
         {
-            byte[] buffer = new byte[length];
+            var length = buffer.Length;
             if (_didBack)
             {
                 buffer[0] = _lastRead;
@@ -192,7 +193,7 @@ namespace Bencodex
                 return _lastRead;
             }
 
-            byte[] buffer = Read(1);
+            byte[] buffer = Read(TinyBuffer);
             return buffer.Length > 0 ? buffer[0] : (byte?)null;
         }
 
@@ -211,7 +212,8 @@ namespace Bencodex
 
         private byte[] ReadDigits(bool takeMinusSign, byte delimiter)
         {
-            byte[] buffer = Read(1);
+            byte[] buffer = new byte[1];
+            buffer = Read(buffer);
 
             if (buffer.Length < 1)
             {
@@ -226,7 +228,7 @@ namespace Bencodex
             if (takeMinusSign && buffer[0] == 0x2d) // '-'
             {
                 minus = true;
-                buffer = Read(1);
+                buffer = Read(buffer);
             }
 
             byte lastByte = buffer[0];
@@ -298,7 +300,8 @@ namespace Bencodex
             }
 
             int pos = _offset;
-            byte[] bytes = Read(length);
+            byte[] buffer = new byte[length];
+            byte[] bytes = Read(buffer);
             if (bytes.Length < length)
             {
                 throw new DecodingException(

--- a/Bencodex/Types/Binary.cs
+++ b/Bencodex/Types/Binary.cs
@@ -182,12 +182,7 @@ namespace Bencodex.Types
         }
 
         [Pure]
-        byte[] IKey.EncodeAsByteArray()
-        {
-            byte[] dest = new byte[Value.Length];
-            Array.Copy(Value, dest, Value.Length);
-            return dest;
-        }
+        byte[] IKey.EncodeAsByteArray() => Value;
 
         [Pure]
         public IEnumerable<byte[]> EncodeIntoChunks()


### PR DESCRIPTION
This PR fixes decode related methods and allocations to reduce the decoding time. Please see the commits as well.

---

Before:
```
Loading 00:00:00.0754400
Codec   00:00:09.3419490
Total   00:00:09.4173890
```

After:
```
Loading 00:00:00.0735380
Codec   00:00:07.6464170
Total   00:00:07.7199550
```