### PR TITLE
Implement declarative serializer

### DIFF
--- a/Bencodex.Tests/Declarative/BencodexSerializerTest.cs
+++ b/Bencodex.Tests/Declarative/BencodexSerializerTest.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.Serialization;
+using Bencodex.Declarative;
+using Bencodex.Types;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Bencodex.Tests.Declarative
+{
+    public class BencodexSerializerTest
+    {
+        private static readonly Dictionary<string, InnerStruct>
+            DictionaryFixture = new Dictionary<string, InnerStruct>
+            {
+                ["first"] = new InnerStruct { String = "first" },
+                ["second"] = new InnerStruct { String = "second" },
+            };
+
+        private static readonly List<InnerStruct> ListFixture = new List<InnerStruct>
+        {
+            new InnerStruct { String = "first" },
+            new InnerStruct { String = "second" },
+        };
+
+        private static readonly Bencodex.Types.Dictionary BencodexDictionaryFixture =
+            Bencodex.Types.Dictionary.Empty
+                .Add(
+                    "first",
+                    Bencodex.Types.Dictionary.Empty.Add(
+                        "string",
+                        "first"))
+                .Add(
+                    "second",
+                    Bencodex.Types.Dictionary.Empty.Add(
+                        "string",
+                        "second"));
+
+        private static readonly Bencodex.Types.List BencodexListFixture =
+            new Bencodex.Types.List(
+                new IValue[]
+                {
+                    Bencodex.Types.Dictionary.Empty
+                        .Add("string", "first"),
+                    Bencodex.Types.Dictionary.Empty
+                        .Add("string", "second"),
+                }
+            );
+
+        private static readonly Struct Fixture = new Struct
+        {
+            String = "string",
+            ByteArray = new byte[] { 0x01, 0x02, 0x03, 0x04 },
+            Bool = true,
+            Int16 = short.MaxValue,
+            Int32 = int.MaxValue,
+            Int64 = long.MaxValue,
+            UInt16 = ushort.MaxValue,
+            UInt32 = uint.MaxValue,
+            UInt64 = ulong.MaxValue,
+
+            Dictionary = DictionaryFixture,
+            ImmutableDictionary = DictionaryFixture.ToImmutableDictionary(),
+            List = ListFixture,
+            ImmutableList = ListFixture.ToImmutableList(),
+
+            Text = "text",
+            Binary = new byte[] { 0x05, 0x06, 0x07, 0x08 },
+            Boolean = true,
+            Integer = ulong.MaxValue,
+            BencodexDictionary = Bencodex.Types.Dictionary.Empty,
+            BencodexList = default(Bencodex.Types.List),
+
+            InnerStruct = new InnerStruct
+            {
+                String = "string",
+            },
+
+            NotAnnotatedField = "string",
+        };
+
+        private static readonly Bencodex.Types.Dictionary SerializedFixture =
+            Bencodex.Types.Dictionary.Empty
+                .SetItem("string", "string")
+                .SetItem("byte_array", new byte[] { 0x01, 0x02, 0x03, 0x04 })
+                .SetItem("bool", true)
+                .SetItem("int16", short.MaxValue)
+                .SetItem("int32", int.MaxValue)
+                .SetItem("int64", long.MaxValue)
+                .SetItem("uint16", ushort.MaxValue)
+                .SetItem("uint32", uint.MaxValue)
+                .SetItem("uint64", ulong.MaxValue)
+                .SetItem("dictionary", BencodexDictionaryFixture)
+                .SetItem("immutable_dictionary", BencodexDictionaryFixture)
+                .SetItem("list", (IValue)BencodexListFixture)
+                .SetItem("immutable_list", (IValue)BencodexListFixture)
+                .SetItem("bencodex.text", (IValue)new Text("text"))
+                .SetItem(
+                    "bencodex.binary",
+                    (IValue)new Binary(new byte[] { 0x05, 0x06, 0x07, 0x08 }))
+                .SetItem(
+                    "bencodex.boolean",
+                    (IValue)new Bencodex.Types.Boolean(true))
+                .SetItem(
+                    "bencodex.integer",
+                    (IValue)new Integer(ulong.MaxValue))
+                .SetItem(
+                    "bencodex.dictionary",
+                    Bencodex.Types.Dictionary.Empty)
+                .SetItem("bencodex.list", (IValue)default(Bencodex.Types.List))
+                .SetItem(
+                    "inner_struct",
+                    Bencodex.Types.Dictionary.Empty.SetItem(
+                        "string",
+                        "string"));
+
+        [Fact]
+        public void SerializeStruct()
+        {
+            var serialized = BencodexSerializer<Struct>.Serialize(Fixture);
+
+            Assert.Equal(SerializedFixture, serialized);
+        }
+
+        [Fact]
+        public void DeserializeStruct()
+        {
+            var deserialized =
+                BencodexSerializer<Struct>.Deserialize(SerializedFixture);
+
+            Assert.Equal(Fixture.String, deserialized.String);
+            Assert.Equal(Fixture.ByteArray, deserialized.ByteArray);
+            Assert.Equal(Fixture.Bool, deserialized.Bool);
+            Assert.Equal(Fixture.Int16, deserialized.Int16);
+            Assert.Equal(Fixture.Int32, deserialized.Int32);
+            Assert.Equal(Fixture.Int64, deserialized.Int64);
+            Assert.Equal(Fixture.UInt16, deserialized.UInt16);
+            Assert.Equal(Fixture.UInt32, deserialized.UInt32);
+            Assert.Equal(Fixture.UInt64, deserialized.UInt64);
+            Assert.Equal(Fixture.Text, deserialized.Text);
+            Assert.Equal(Fixture.Binary, deserialized.Binary);
+            Assert.Equal(Fixture.Boolean, deserialized.Boolean);
+            Assert.Equal(Fixture.Integer, deserialized.Integer);
+            Assert.Equal(Fixture.Dictionary, deserialized.Dictionary);
+            Assert.Equal(Fixture.List, deserialized.List);
+            Assert.Equal(Fixture.ImmutableList, deserialized.ImmutableList);
+            Assert.Equal(Fixture.InnerStruct.String, deserialized.InnerStruct.String);
+        }
+
+        [Fact]
+        public void SerializeClass()
+        {
+            var serialized = BencodexSerializer<Class>.Serialize(new Class
+            {
+                Property = "property",
+            });
+
+            Assert.Equal(
+                serialized,
+                Bencodex.Types.Dictionary.Empty.Add("property", "property"));
+        }
+
+        [Fact]
+        public void DeserializeClass()
+        {
+            var expected = new Class
+            {
+                Property = "property",
+            };
+
+            var deserialized = BencodexSerializer<Class>.Deserialize(
+                Bencodex.Types.Dictionary.Empty.Add("property", "property"));
+
+            Assert.Equal(
+                expected,
+                deserialized);
+        }
+
+        [Fact]
+        public void DetectNotAnnotatedStruct()
+        {
+            Assert.Throws<BencodexSerializationException>(
+                () => BencodexSerializer<NotMarkedStruct>.Serialize(default));
+            Assert.Throws<BencodexSerializationException>(
+                () => BencodexSerializer<NotMarkedClass>.Serialize(default));
+        }
+
+        [BencodexObject]
+        private struct InnerStruct : IComparable<InnerStruct>
+        {
+            [BencodexProperty("string")]
+            public string String;
+
+            public int CompareTo(InnerStruct other)
+            {
+                return String.CompareTo(other.String);
+            }
+        }
+
+        [BencodexObject]
+        private struct Struct
+        {
+            [BencodexProperty("string")]
+            public string String;
+
+            [BencodexProperty("byte_array")]
+            public byte[] ByteArray;
+
+            [BencodexProperty("bool")]
+            public bool Bool;
+
+            [BencodexProperty("int16")]
+            public short Int16;
+
+            [BencodexProperty("int32")]
+            public int Int32;
+
+            [BencodexProperty("int64")]
+            public long Int64;
+
+            [BencodexProperty("uint16")]
+            public ushort UInt16;
+
+            [BencodexProperty("uint32")]
+            public uint UInt32;
+
+            [BencodexProperty("uint64")]
+            public ulong UInt64;
+
+            [BencodexProperty("dictionary")]
+            public Dictionary<string, InnerStruct> Dictionary;
+
+            [BencodexProperty("immutable_dictionary")]
+            public ImmutableDictionary<string, InnerStruct> ImmutableDictionary;
+
+            [BencodexProperty("list")]
+            public List<InnerStruct> List;
+
+            [BencodexProperty("immutable_list")]
+            public ImmutableList<InnerStruct> ImmutableList;
+
+            [BencodexProperty("bencodex.text")]
+            public Bencodex.Types.Text Text;
+
+            [BencodexProperty("bencodex.binary")]
+            public Bencodex.Types.Binary Binary;
+
+            [BencodexProperty("bencodex.boolean")]
+            public Bencodex.Types.Boolean Boolean;
+
+            [BencodexProperty("bencodex.integer")]
+            public Bencodex.Types.Integer Integer;
+
+            [BencodexProperty("bencodex.dictionary")]
+            public Bencodex.Types.Dictionary BencodexDictionary;
+
+            [BencodexProperty("bencodex.list")]
+            public Bencodex.Types.List BencodexList;
+
+            [BencodexProperty("inner_struct")]
+            public InnerStruct InnerStruct;
+
+            public string NotAnnotatedField;
+        }
+
+        private struct NotMarkedStruct
+        {
+        }
+
+        [BencodexObject]
+        private class Class : IComparable<Class>
+        {
+            [BencodexProperty("property")]
+            public string Property { get; internal set; }
+
+            public int CompareTo(Class other)
+            {
+                return string.Compare(
+                    Property,
+                    other.Property,
+                    StringComparison.Ordinal);
+            }
+        }
+
+        private class NotMarkedClass
+        {
+        }
+    }
+}

--- a/Bencodex/Declarative/BencodexObjectAttribute.cs
+++ b/Bencodex/Declarative/BencodexObjectAttribute.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Bencodex.Declarative
+{
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct)]
+    public class BencodexObjectAttribute : Attribute
+    {
+    }
+}

--- a/Bencodex/Declarative/BencodexPropertyAttribute.cs
+++ b/Bencodex/Declarative/BencodexPropertyAttribute.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Bencodex.Declarative
+{
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public class BencodexPropertyAttribute : Attribute
+    {
+        public BencodexPropertyAttribute(string name)
+        {
+            Name = name;
+        }
+
+        public string Name { get; }
+    }
+}

--- a/Bencodex/Declarative/BencodexSerializationException.cs
+++ b/Bencodex/Declarative/BencodexSerializationException.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Bencodex.Declarative
+{
+    public class BencodexSerializationException : Exception
+    {
+        public BencodexSerializationException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/Bencodex/Declarative/BencodexSerializer.cs
+++ b/Bencodex/Declarative/BencodexSerializer.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using Bencodex.Types;
+
+namespace Bencodex.Declarative
+{
+    public class BencodexSerializer<T>
+        where T : new()
+    {
+        public static Dictionary Serialize(T obj)
+        {
+            var members = GetFields().Cast<MemberInfo>().Union(GetProperties()).ToList();
+            var names = members
+                .Select(field =>
+                    field.GetCustomAttribute(typeof(BencodexPropertyAttribute))
+                        as BencodexPropertyAttribute)
+                .Where(attr => attr != null)
+                .Select(attr => attr!.Name);
+            var dictionary = default(Dictionary);
+            foreach (var (member, fieldName) in members.Zip(names, ValueTuple.Create))
+            {
+                object value;
+                if (member is FieldInfo field)
+                {
+                    value = field.GetValue(obj);
+                }
+                else
+                {
+                    value = (member as PropertyInfo)!.GetValue(obj);
+                }
+
+                var converted = ToBencodex(value);
+                dictionary = dictionary.SetItem(fieldName, converted);
+            }
+
+            return dictionary;
+        }
+
+        public static T Deserialize(Dictionary dictionary)
+        {
+            var members = GetFields().Cast<MemberInfo>().Union(GetProperties()).ToList();
+            var names = members
+                .Select(member =>
+                    member.GetCustomAttribute(typeof(BencodexPropertyAttribute))
+                        as BencodexPropertyAttribute)
+                .Where(attr => attr != null)
+                .Select(attr => attr!.Name);
+            var obj = new T();
+            foreach (var (member, fieldName) in members.Zip(names, ValueTuple.Create))
+            {
+                var value = dictionary[fieldName];
+                if (member is FieldInfo field)
+                {
+                    var converted = FromBencodex(value, field.FieldType);
+                    field.SetValueDirect(__makeref(obj), converted);
+                }
+                else
+                {
+                    var property = (PropertyInfo)member;
+                    var converted = FromBencodex(value, property.PropertyType);
+                    property.SetValue(obj, converted);
+                }
+            }
+
+            return obj;
+        }
+
+        private static IValue ToBencodex(object obj)
+        {
+            if (obj is IValue value)
+            {
+                return value;
+            }
+
+            if (obj.GetType().IsDefined(typeof(BencodexObjectAttribute)))
+            {
+                var deserializeMethod = typeof(BencodexSerializer<>)
+                    .MakeGenericType(obj.GetType()).GetMethod(nameof(Serialize));
+                return (IValue)deserializeMethod.Invoke(null, new object[] { obj });
+            }
+
+            switch (obj)
+            {
+                case short s:
+                    return (Integer)s;
+                case int i:
+                    return (Integer)i;
+                case long l:
+                    return (Integer)l;
+                case ushort us:
+                    return (Integer)us;
+                case uint ui:
+                    return (Integer)ui;
+                case ulong ul:
+                    return (Integer)ul;
+                case string s:
+                    return (Text)s;
+                case byte[] bytes:
+                    return (Binary)bytes;
+                case bool b:
+                    return new Bencodex.Types.Boolean(b);
+                case IList list:
+                    var values = new List<IValue>();
+                    foreach (var v in list)
+                    {
+                        values.Add(ToBencodex(v));
+                    }
+
+                    return new Bencodex.Types.List(values);
+                case IDictionary dictionary:
+                    var entries = new List<KeyValuePair<IKey, IValue>>();
+                    foreach (var k in dictionary.Keys)
+                    {
+                        var v = dictionary[k];
+                        entries.Add(
+                            new KeyValuePair<IKey, IValue>(
+                                (IKey)ToBencodex(k),
+                                ToBencodex(v)));
+                    }
+
+                    return new Bencodex.Types.Dictionary(entries);
+                default:
+                    throw new BencodexSerializationException(
+                        string.Format(
+                            "{0} type isn't supported in {1}.",
+                            obj.GetType().FullName,
+                            nameof(ToBencodex)));
+            }
+        }
+
+        private static object FromBencodex(IValue value, Type to)
+        {
+            if (typeof(IValue).IsAssignableFrom(to))
+            {
+                return value;
+            }
+
+            switch (value)
+            {
+                case Text text:
+                    return (string)text;
+
+                case Binary binary:
+                    return (byte[])binary;
+
+                case Bencodex.Types.Boolean boolean:
+                    return (bool)boolean;
+
+                case Integer integer:
+                    if (to == typeof(short))
+                    {
+                        return (short)integer;
+                    }
+                    else if (to == typeof(int))
+                    {
+                        return (int)integer;
+                    }
+                    else if (to == typeof(long))
+                    {
+                        return (long)integer;
+                    }
+                    else if (to == typeof(ushort))
+                    {
+                        return (ushort)integer;
+                    }
+                    else if (to == typeof(uint))
+                    {
+                        return (uint)integer;
+                    }
+                    else if (to == typeof(ulong))
+                    {
+                        return (ulong)integer;
+                    }
+                    else
+                    {
+                        throw new BencodexSerializationException(
+                            $"Can't convert {nameof(Bencodex.Types.Integer)} to {to.FullName}."
+                            + "It isn't supported yet or it seems to be tried to reverse alignment to a different type than when serializing.'");
+                    }
+
+                case Bencodex.Types.Dictionary dictionary:
+                    if (to.IsDefined(typeof(BencodexObjectAttribute)))
+                    {
+                        return typeof(BencodexSerializer<>)
+                            .MakeGenericType(to)
+                            .GetMethod(nameof(Deserialize))
+                            .Invoke(null, new object[] { value });
+                    }
+                    else
+                    {
+                        return GetDictionaryFromBencodex(dictionary, to);
+                    }
+
+                case Bencodex.Types.List list:
+                    if (to.IsGenericType &&
+                        typeof(IList).IsAssignableFrom(to))
+                    {
+                        return GetListFromBencodex(list, to);
+                    }
+                    else
+                    {
+                        throw new BencodexSerializationException(
+                            $"Can't convert {nameof(Bencodex.Types.List)} to {to.FullName}."
+                            + "It's not supported yet or it seems to be tried to reverse alignment to a different type than when serializing.'");
+                    }
+
+                default:
+                    throw new BencodexSerializationException("Not Supported");
+            }
+        }
+
+        private static object GetListFromBencodex(
+            Bencodex.Types.List list,
+            Type to)
+        {
+            var genericType = to.GetGenericArguments()[0];
+            var listTypeWithGeneric =
+                typeof(List<>).MakeGenericType(genericType);
+            IList l = (IList)Activator.CreateInstance(listTypeWithGeneric);
+            foreach (var v in list)
+            {
+                l.Add(FromBencodex(v, genericType));
+            }
+
+            if (to.GetGenericTypeDefinition() == typeof(ImmutableList<>))
+            {
+                return typeof(ImmutableList)
+                    .GetMethod("CreateRange")
+                    .MakeGenericMethod(genericType)
+                    .Invoke(null, new object[] { l });
+            }
+
+            return l;
+        }
+
+        private static object GetDictionaryFromBencodex(
+            Bencodex.Types.Dictionary dictionary, Type to)
+        {
+            var genericTypeArguments =
+                to.GenericTypeArguments;
+            var dictionaryTypeWithGeneric =
+                to.GetGenericTypeDefinition().MakeGenericType(
+                    genericTypeArguments[0],
+                    genericTypeArguments[1]);
+            var keyValuePairTypeWithGeneric =
+                typeof(KeyValuePair<,>).MakeGenericType(
+                    genericTypeArguments[0],
+                    genericTypeArguments[1]);
+            var keyValuePairListType =
+                typeof(List<>).MakeGenericType(keyValuePairTypeWithGeneric);
+            var pairs = (IList)Activator.CreateInstance(
+                keyValuePairListType);
+
+            foreach (var entry in dictionary)
+            {
+                var pair = Activator.CreateInstance(
+                    keyValuePairTypeWithGeneric,
+                    FromBencodex(
+                        entry.Key,
+                        genericTypeArguments[0]),
+                    FromBencodex(
+                        entry.Value,
+                        genericTypeArguments[1])
+                );
+                pairs.Add(pair);
+            }
+
+            if (typeof(ImmutableDictionary<,>) ==
+                to.GetGenericTypeDefinition())
+            {
+                return typeof(ImmutableDictionary)
+                    .GetMethods()
+                    .Single(m =>
+                        m.GetParameters().Length == 1 &&
+                        m.Name == "CreateRange")
+                    .MakeGenericMethod(
+                        genericTypeArguments[0],
+                        genericTypeArguments[1])
+                    .Invoke(null, new object[] { pairs });
+            }
+
+            return
+                Activator.CreateInstance(
+                    dictionaryTypeWithGeneric,
+                    pairs);
+        }
+
+        private static IEnumerable<FieldInfo> GetFields()
+        {
+            CheckMarkedType();
+
+            var bindingFlags = BindingFlags.Instance | BindingFlags.Public |
+                               BindingFlags.NonPublic;
+            return typeof(T)
+                .GetFields(bindingFlags)
+                .Where(field =>
+                    field.IsDefined(
+                        typeof(BencodexPropertyAttribute),
+                        false));
+        }
+
+        private static IEnumerable<PropertyInfo> GetProperties()
+        {
+            CheckMarkedType();
+
+            var bindingFlags = BindingFlags.Instance | BindingFlags.Public |
+                               BindingFlags.NonPublic;
+            return typeof(T)
+                .GetProperties(bindingFlags)
+                .Where(property =>
+                    property.IsDefined(
+                        typeof(BencodexPropertyAttribute),
+                        false));
+        }
+
+        private static void CheckMarkedType()
+        {
+            if (!typeof(T).IsDefined(typeof(BencodexObjectAttribute), false))
+            {
+                throw new BencodexSerializationException(
+                    $"The type is not marked with {nameof(BencodexObjectAttribute)}.");
+            }
+        }
+    }
+}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -108,7 +108,12 @@ To be released.
     hash table, but do it when it needs (e.g., when to look up a key) instead.
     Note that this change does not cause any API changes, but just purposes
     faster instantiation.  [[#33], [#34]]
+ -  Added `Bencodex.Declarative.BencodexSerializer<T>.Serialize(object)`.  [[#6], [#38]]
+ -  Added `Bencodex.Declarative.BencodexSerializer<T>
+    .Deserialize(Bencodex.Types.Dictionary)`.  [[#6], [#38]]
 
+
+[#6]: https://github.com/planetarium/bencodex.net/issues/6
 [#7]: https://github.com/planetarium/bencodex.net/pull/7
 [#11]: https://github.com/planetarium/bencodex.net/pull/11
 [#12]: https://github.com/planetarium/bencodex.net/issues/12
@@ -125,6 +130,7 @@ To be released.
 [#33]: https://github.com/planetarium/bencodex.net/pull/33
 [#34]: https://github.com/planetarium/bencodex.net/pull/34
 [#37]: https://github.com/planetarium/bencodex.net/pull/37
+[#38]: https://github.com/planetarium/bencodex.net/pull/38
 [nullable reference types]: https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references
 [RTL]: https://en.wikipedia.org/wiki/Right-to-left
 [FNV]: https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function


### PR DESCRIPTION
It's related with issue #6, *proposal.3*.

This pull request will make enable code like below. but it's in process yet.

```csharp
[BencodexObject]
class Person {
  [BencodexProperty("name")]
  public string Name;
}

[BencodexObject]
class Group {
  [BencodexProperty("peoples")]
  public ImmutableList<People> Peoples;
}

var group = new Group {
  Peoples = ImmutableList<People>.Empty
    .Add(new People { Name = "Alex" })
};
var serialized = BencodexSerializer<Group>.Serialize(group);
/*
{
  "peoples": [
    { "name": "Alex" }
  ]
}
*/
```