### PR TITLE
`ImmutableArray<byte>`-based `Binary`

### DIFF
--- a/Bencodex.Tests/Misc/ByteArrayComparerTest.cs
+++ b/Bencodex.Tests/Misc/ByteArrayComparerTest.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using Bencodex.Misc;
 using Xunit;
 
@@ -7,7 +8,7 @@ namespace Bencodex.Tests.Misc
     public class ByteArrayComparerTest
     {
         [Fact]
-        public void TestComparison()
+        public void CompareMutableArrays()
         {
             var comparer = default(ByteArrayComparer);
             ComparerTestUtils.TestComparison(
@@ -23,6 +24,27 @@ namespace Bencodex.Tests.Misc
                     new byte[] { 0x01, 0x01 },
                     new byte[] { 0x01, 0x80 },
                     new byte[] { 0x01, 0xff },
+                }
+            );
+        }
+
+        [Fact]
+        public void CompareImmutableArrays()
+        {
+            var comparer = default(ByteArrayComparer);
+            ComparerTestUtils.TestComparison(
+                comparer,
+                new List<ImmutableArray<byte>>()
+                {
+                    ImmutableArray<byte>.Empty,
+                    new byte[] { 0x00 }.ToImmutableArray(),
+                    new byte[] { 0x00, 0x00 }.ToImmutableArray(),
+                    new byte[] { 0x00, 0x80 }.ToImmutableArray(),
+                    new byte[] { 0x00, 0xff }.ToImmutableArray(),
+                    new byte[] { 0x01 }.ToImmutableArray(),
+                    new byte[] { 0x01, 0x01 }.ToImmutableArray(),
+                    new byte[] { 0x01, 0x80 }.ToImmutableArray(),
+                    new byte[] { 0x01, 0xff }.ToImmutableArray(),
                 }
             );
         }

--- a/Bencodex.Tests/Misc/ImplicitConversionTest.cs
+++ b/Bencodex.Tests/Misc/ImplicitConversionTest.cs
@@ -41,8 +41,11 @@ namespace Bencodex.Tests.Misc
         {
             var binary = new Binary(new byte[] { 0x01, 0x02, 0x03 });
 
-            byte[] bytes = binary;
-            Assert.Equal(bytes, binary.Value);
+            ImmutableArray<byte> immutable = binary;
+            Assert.Equal(immutable, binary.ByteArray);
+
+            byte[] mutable = binary;
+            Assert.Equal(mutable, binary.ToByteArray());
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/BinaryTest.cs
+++ b/Bencodex.Tests/Types/BinaryTest.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Text;
 using Bencodex.Types;
 using Xunit;
@@ -16,33 +17,54 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
-        public void Constructor()
+        public void DefaultConstructor()
         {
-            Assert.NotNull(default(Binary).Value);
-            Assert.Empty(default(Binary).Value);
-
-            var hello = new Binary(new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f });
-            Assert.Equal(
-                new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f },
-                hello.Value
-            );
-
-            var fromString = new Binary("hello", Encoding.ASCII);
-            Assert.Equal(hello.Value, fromString.Value);
+            Assert.Empty(default(Binary).ByteArray);
+            Assert.NotNull(default(Binary).ToByteArray());
+            Assert.Empty(default(Binary).ToByteArray());
         }
 
         [Fact]
-        public void Immutability()
+        public void ConstructorTakingImmutableByteArray()
         {
+            ImmutableArray<byte> bytes =
+                new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f }.ToImmutableArray();
+            var hello = new Binary(bytes);
+            Assert.Equal(bytes, hello.ByteArray);
             Assert.Equal(
                 new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f },
-                _hello.Value
+                hello.ToByteArray()
             );
+        }
 
-            _hello.Value[3] = 0x6f;
+        [Fact]
+        public void ConstructorTakingByteArray()
+        {
+            var hello = new Binary(new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f });
             Assert.Equal(
                 new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f },
-                _hello.Value
+                hello.ToByteArray()
+            );
+        }
+
+        [Fact]
+        public void ConstructorTakingString()
+        {
+            var hello = new Binary(new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f });
+            var fromString = new Binary("hello", Encoding.ASCII);
+            Assert.Equal(hello, fromString);
+        }
+
+        [Fact]
+        public void ToByteArray()
+        {
+            byte[] a = _hello.ToByteArray();
+            Assert.Equal(new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f }, a);
+
+            a[3] = 0x6f;
+            Assert.Equal(
+                new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f },
+                _hello.ToByteArray()
             );
         }
 
@@ -50,9 +72,20 @@ namespace Bencodex.Tests.Types
         public void Equality()
         {
             Assert.Equal(_empty, new Binary(new byte[0]));
+            Assert.Equal(_empty, ImmutableArray<byte>.Empty);
+            Assert.Equal(_empty, new byte[0]);
+
             Assert.Equal(
                 _hello,
                 new Binary(new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f })
+            );
+            Assert.Equal(
+                _hello,
+                new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f }.ToImmutableArray<byte>()
+            );
+            Assert.Equal(
+                _hello,
+                new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f }
             );
 
             Assert.NotEqual(_empty, _hello);

--- a/Bencodex/Misc/ByteArrayComparer.cs
+++ b/Bencodex/Misc/ByteArrayComparer.cs
@@ -1,17 +1,42 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Bencodex.Misc
 {
-    /// <summary>Similar to <c cref="StringComparer">StringComparer</c>
-    /// but for <c cref="byte">Byte</c> arrays instead of
-    /// Unicode <c cref="string">String</c>s.</summary>
-    public struct ByteArrayComparer : IComparer<byte[]>
+    /// <summary>
+    /// Similar to <see cref="StringComparer"/> but for <see cref="byte"/>s instead of Unicode
+    /// <see cref="string"/>s.
+    /// </summary>
+    public struct ByteArrayComparer
+        : IComparer<byte[]>, IComparer<ImmutableArray<byte>>, IComparer<IReadOnlyList<byte>>
     {
-        public int Compare(byte[] x, byte[] y)
+        private static readonly ByteArrayComparer<byte[]> _mutableArrayComparer =
+            new ByteArrayComparer<byte[]>();
+
+        private static readonly ByteArrayComparer<ImmutableArray<byte>> _immutableArrayComparer =
+            new ByteArrayComparer<ImmutableArray<byte>>();
+
+        private static readonly ByteArrayComparer<IReadOnlyList<byte>> _readOnlyListComparer =
+            new ByteArrayComparer<IReadOnlyList<byte>>();
+
+        public int Compare(byte[] x, byte[] y) =>
+            _mutableArrayComparer.Compare(x, y);
+
+        public int Compare(ImmutableArray<byte> x, ImmutableArray<byte> y) =>
+            _immutableArrayComparer.Compare(x, y);
+
+        public int Compare(IReadOnlyList<byte> x, IReadOnlyList<byte> y) =>
+            _readOnlyListComparer.Compare(x, y);
+    }
+
+    internal class ByteArrayComparer<T> : IComparer<T>
+        where T : IReadOnlyList<byte>
+    {
+        public int Compare(T x, T y)
         {
-            int shortestLength = Math.Min(x.Length, y.Length);
+            int shortestLength = Math.Min(x.Count, y.Count);
             for (int i = 0; i < shortestLength; i++)
             {
                 int c = x[i].CompareTo(y[i]);
@@ -21,7 +46,7 @@ namespace Bencodex.Misc
                 }
             }
 
-            return x.Length.CompareTo(y.Length);
+            return x.Count.CompareTo(y.Count);
         }
     }
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,14 @@ To be released.
     to support [nullable reference types].  [[#24]]
  -  `Bencodex.Types.Null` became a read-only struct.  [[#37]]
  -  Added `Bencodex.Types.Null.Value` read-only field.  [[#20], [#37]]
+ -  `Bencodex.Types.Binary`'s internal representation became
+    `ImmutableArray<byte>` instead of `byte[]`.  [[#39]]
+    - `Binary` became to implement `IEquatable<ImmutableArray<byte>>`.
+    - `Binary` became to implement `IComparer<ImmutableArray<byte>>`.
+    - Added `Binary(ImmutableArray<byte>)` constructor.
+    - `Binary.Value` property became obsolete.
+    - Added `Binary.ByteArray` property.
+    - Added `Binary.ToByteArray()` method.
  -  `Bencodex.Types.Dictionary` became a read-only struct.  [[#24]]
  -  `Bencodex.Types.Dictionary(IEnumerable<KeyValuePair<IKey, IValue>>)`
     constructor now has no default value for the parameter.  [[#24]]
@@ -108,6 +116,8 @@ To be released.
     hash table, but do it when it needs (e.g., when to look up a key) instead.
     Note that this change does not cause any API changes, but just purposes
     faster instantiation.  [[#33], [#34]]
+ -  `Bencodex.Misc.ByteArrayComparer` now implements
+    `IComparer<ImmutableArray<byte>>` besides `IComparer<byte[]>`.  [[#39]]
 
 [#7]: https://github.com/planetarium/bencodex.net/pull/7
 [#11]: https://github.com/planetarium/bencodex.net/pull/11
@@ -125,6 +135,7 @@ To be released.
 [#33]: https://github.com/planetarium/bencodex.net/pull/33
 [#34]: https://github.com/planetarium/bencodex.net/pull/34
 [#37]: https://github.com/planetarium/bencodex.net/pull/37
+[#39]: https://github.com/planetarium/bencodex.net/pull/39
 [nullable reference types]: https://docs.microsoft.com/en-us/dotnet/csharp/nullable-references
 [RTL]: https://en.wikipedia.org/wiki/Right-to-left
 [FNV]: https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function


### PR DESCRIPTION
In order to reduce unnecessary round-trips and memory copies, this patch rebased `Binary` on `ImmutableArray<byte>`.