### PR TITLE
Trailing commas in multiline `Inspection` string

### DIFF
--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -324,19 +324,19 @@ namespace Bencodex.Tests.Types
 
             var one = Dictionary.Empty.SetItem("foo", "bar");
             Assert.Equal(
-                "{\n  \"foo\": \"bar\"\n}",
+                "{\n  \"foo\": \"bar\",\n}",
                 one.Inspection
             );
             Assert.Equal(
-                "{\n  b\"\\x66\\x6f\\x6f\": \"bar\"\n}",
+                "{\n  b\"\\x66\\x6f\\x6f\": \"bar\",\n}",
                 Dictionary.Empty.SetItem(Encoding.ASCII.GetBytes("foo"), "bar").Inspection
             );
             Assert.Equal(
                 @"{
   ""baz"": {
-    ""foo"": ""bar""
+    ""foo"": ""bar"",
   },
-  ""foo"": ""bar""
+  ""foo"": ""bar"",
 }".NoCr(),
                 one.SetItem("baz", one).Inspection
             );
@@ -350,7 +350,7 @@ namespace Bencodex.Tests.Types
                 Dictionary.Empty.ToString()
             );
             Assert.Equal(
-                "Bencodex.Types.Dictionary {\n  \"foo\": \"bar\"\n}",
+                "Bencodex.Types.Dictionary {\n  \"foo\": \"bar\",\n}",
                 Dictionary.Empty.SetItem("foo", "bar").ToString()
             );
         }

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -33,7 +33,7 @@ namespace Bencodex.Tests.Types
         {
             Assert.Equal("[]", _zero.Inspection);
             Assert.Equal("[null]", _one.Inspection);
-            Assert.Equal("[\n  \"hello\",\n  \"world\"\n]", _two.Inspection);
+            Assert.Equal("[\n  \"hello\",\n  \"world\",\n]", _two.Inspection);
 
             var expected = @"[
   null,
@@ -41,14 +41,14 @@ namespace Bencodex.Tests.Types
   [null],
   [
     ""hello"",
-    ""world""
-  ]
+    ""world"",
+  ],
 ]".NoCr();
             Assert.Equal(expected, _nest.Inspection);
 
             // If any element is a list/dict it should be indented
-            Assert.Equal("[\n  []\n]", new List(new IValue[] { _zero }).Inspection);
-            Assert.Equal("[\n  {}\n]", new List(new IValue[] { Dictionary.Empty }).Inspection);
+            Assert.Equal("[\n  [],\n]", new List(new IValue[] { _zero }).Inspection);
+            Assert.Equal("[\n  {},\n]", new List(new IValue[] { Dictionary.Empty }).Inspection);
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace Bencodex.Tests.Types
             Assert.Equal("Bencodex.Types.List []", _zero.ToString());
             Assert.Equal("Bencodex.Types.List [null]", _one.ToString());
             Assert.Equal(
-                "Bencodex.Types.List [\n  \"hello\",\n  \"world\"\n]",
+                "Bencodex.Types.List [\n  \"hello\",\n  \"world\",\n]",
                 _two.ToString()
             );
         }

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -57,10 +57,10 @@ namespace Bencodex.Types
                 }
 
                 IEnumerable<string> pairs = this.Select(kv =>
-                    $"{kv.Key.Inspection}: {kv.Value.Inspection.Replace("\n", "\n  ")}"
+                    $"  {kv.Key.Inspection}: {kv.Value.Inspection.Replace("\n", "\n  ")},\n"
                 ).OrderBy(s => s);
-                string pairsString = string.Join(",\n  ", pairs);
-                return $"{{\n  {pairsString}\n}}";
+                string pairsString = string.Join(string.Empty, pairs);
+                return $"{{\n{pairsString}}}";
             }
         }
 

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -49,9 +49,9 @@ namespace Bencodex.Types
 
                     default:
                         IEnumerable<string> elements = this.Select(v =>
-                            v.Inspection.Replace("\n", "\n  ")
+                            $"  {v.Inspection.Replace("\n", "\n  ")},\n"
                         );
-                        return $"[\n  {string.Join(",\n  ", elements)}\n]";
+                        return $"[\n{string.Join(string.Empty, elements)}]";
                 }
             }
         }


### PR DESCRIPTION
This patch adds trailing commas to `Dictionary.Inspection` & `List.Inspection`.  This is better for generating diffs between two `IValue.Inspection` trees.

Before:

```
[
  "foo",
  b"bar",
  {
    "baz": "qux",
    "quux": 1234
  },
  null
]
```


After:

```
[
  "foo",
  b"bar",
  {
    "baz": "qux",
    "quux": 1234,
  },
  null,
]
```

Diff:

```udiff
--- before	2021-10-01 10:51:29.000000000 +0900
+++ after	2021-10-01 10:51:26.000000000 +0900
@@ -1,9 +1,9 @@
 [
   "foo",
   b"bar",
   {
     "baz": "qux",
-    "quux": 1234
+    "quux": 1234,
   },
-  null
+  null,
 ]

```