### PR TITLE
Pre-calculated encoding length of values

### DIFF
--- a/Bencodex.Tests/CodecTest.cs
+++ b/Bencodex.Tests/CodecTest.cs
@@ -1,17 +1,28 @@
 using Bencodex.Types;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Bencodex.Tests
 {
     public class CodecTest
     {
+        private readonly ITestOutputHelper _output;
+
+        public CodecTest(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
         [Theory]
         [ClassData(typeof(SpecTheoryData))]
         public void SpecTestSuite(Spec spec)
         {
+            _output.WriteLine("YAML: {0}", spec.SemanticsPath);
+            _output.WriteLine("Data: {0}", spec.EncodingPath);
             Codec codec = new Codec();
             IValue decoded = codec.Decode(spec.Encoding);
             Assert.Equal(spec.Semantics, decoded);
+            Assert.Equal(spec.Encoding.Length, decoded.EncodingLength);
         }
     }
 }

--- a/Bencodex.Tests/Types/BinaryTest.cs
+++ b/Bencodex.Tests/Types/BinaryTest.cs
@@ -101,6 +101,14 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
+        public void EncodingLength()
+        {
+            Assert.Equal(2, _empty.EncodingLength);
+            Assert.Equal(7, _hello.EncodingLength);
+            Assert.Equal(13, new Binary(new byte[10]).EncodingLength);
+        }
+
+        [Fact]
         public void Inspection()
         {
             Assert.Equal("b\"\"", _empty.Inspection);

--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -318,6 +318,19 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
+        public void EncodingLength()
+        {
+            Assert.Equal(2, Dictionary.Empty.EncodingLength);
+            Assert.Equal(
+                14,
+                Dictionary.Empty.SetItem("foo", "bar").EncodingLength
+            );
+            Dictionary binaryKey = Dictionary.Empty
+                .SetItem(Encoding.ASCII.GetBytes("foo"), "bar");
+            Assert.Equal(13, binaryKey.EncodingLength);
+        }
+
+        [Fact]
         public void Inspection()
         {
             Assert.Equal("{}", Dictionary.Empty.Inspection);

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -29,6 +29,15 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
+        public void EncodingLength()
+        {
+            Assert.Equal(2, _zero.EncodingLength);
+            Assert.Equal(3, _one.EncodingLength);
+            Assert.Equal(18, _two.EncodingLength);
+            Assert.Equal(26, _nest.EncodingLength);
+        }
+
+        [Fact]
         public void Inspect()
         {
             Assert.Equal("[]", _zero.Inspection);

--- a/Bencodex.Tests/Types/ValueTests.cs
+++ b/Bencodex.Tests/Types/ValueTests.cs
@@ -29,6 +29,7 @@ namespace Bencodex.Tests.Types
                 _codec.Encode(default(Null))
             );
 
+            Assert.Equal(1, default(Null).EncodingLength);
             Assert.Equal("null", default(Null).Inspection);
             Assert.Equal("Bencodex.Types.Null", default(Null).ToString());
         }
@@ -47,6 +48,8 @@ namespace Bencodex.Tests.Types
                 _codec.Encode(f)
             );
 
+            Assert.Equal(1, t.EncodingLength);
+            Assert.Equal(1, f.EncodingLength);
             Assert.Equal("true", t.Inspection);
             Assert.Equal("false", f.Inspection);
             Assert.Equal("Bencodex.Types.Boolean true", t.ToString());
@@ -73,6 +76,9 @@ namespace Bencodex.Tests.Types
             var locale = new CultureInfo("ar-SA");
             IntegerGeneric(i => new Integer(i.ToString(locale), locale));
 
+            Assert.Equal(3, new Integer(0).EncodingLength);
+            Assert.Equal(5, new Integer(123).EncodingLength);
+            Assert.Equal(6, new Integer(-456).EncodingLength);
             Assert.Equal("123", new Integer(123).Inspection);
             Assert.Equal("-456", new Integer(-456).Inspection);
             Assert.Equal("Bencodex.Types.Integer 123", new Integer(123).ToString());
@@ -118,6 +124,9 @@ namespace Bencodex.Tests.Types
 
             var complex = new Text("new lines and\n\"quotes\" become escaped to \\");
 
+            Assert.Equal(3, empty.EncodingLength);
+            Assert.Equal(9, nihao.EncodingLength);
+            Assert.Equal(46, complex.EncodingLength);
             Assert.Equal("\"\"", empty.Inspection);
             Assert.Equal("\"\u4f60\u597d\"", nihao.Inspection);
             Assert.Equal(

--- a/Bencodex/Types/Binary.cs
+++ b/Bencodex/Types/Binary.cs
@@ -57,6 +57,14 @@ namespace Bencodex.Types
             "method or Binary.ByteArray property instead.")]
         public byte[] Value => ToByteArray();
 
+        /// <inheritdoc cref="IValue.EncodingLength"/>
+        [Pure]
+        public int EncodingLength =>
+            ByteArray.Length.ToString(CultureInfo.InvariantCulture).Length +
+            CommonVariables.Separator.Length +
+            ByteArray.Length;
+
+        /// <inheritdoc cref="IValue.Inspection"/>
         [Pure]
         public string Inspection
         {

--- a/Bencodex/Types/Boolean.cs
+++ b/Bencodex/Types/Boolean.cs
@@ -26,6 +26,11 @@ namespace Bencodex.Types
 
         public bool Value { get; }
 
+        /// <inheritdoc cref="IValue.EncodingLength"/>
+        [Pure]
+        public int EncodingLength => 1;
+
+        /// <inheritdoc cref="IValue.Inspection"/>
         [Pure]
         public string Inspection =>
             Value ? "true" : "false";

--- a/Bencodex/Types/CommonVariables.cs
+++ b/Bencodex/Types/CommonVariables.cs
@@ -1,6 +1,6 @@
 namespace Bencodex.Types
 {
-    public static class CommonVariables
+    internal static class CommonVariables
     {
         internal static readonly byte[] Separator = new byte[1] { 0x3a };  // ':'
 

--- a/Bencodex/Types/IValue.cs
+++ b/Bencodex/Types/IValue.cs
@@ -16,6 +16,10 @@ namespace Bencodex.Types
     /// <seealso cref="Dictionary"/>
     public interface IValue : IEquatable<IValue>
     {
+        /// <summary>The number of bytes used for serializing the value.</summary>
+        [Pure]
+        int EncodingLength { get; }
+
         /// <summary>A JSON-like human-readable representation for
         /// debugging.</summary>
         /// <returns>A JSON-like representation.</returns>

--- a/Bencodex/Types/Integer.cs
+++ b/Bencodex/Types/Integer.cs
@@ -60,6 +60,12 @@ namespace Bencodex.Types
 
         public BigInteger Value { get; }
 
+        /// <inheritdoc cref="IValue.EncodingLength"/>
+        [Pure]
+        public int EncodingLength =>
+            2 + Value.ToString(CultureInfo.InvariantCulture).Length;
+
+        /// <inheritdoc cref="IValue.Inspection"/>
         [Pure]
         public string Inspection =>
             Value.ToString(CultureInfo.InvariantCulture);

--- a/Bencodex/Types/Null.cs
+++ b/Bencodex/Types/Null.cs
@@ -21,8 +21,13 @@ namespace Bencodex.Types
             new Null();
 #pragma warning restore SA1129
 
+        /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
-        public string Inspection => $"null";
+        public int EncodingLength => 1;
+
+        /// <inheritdoc cref="IValue.Inspection"/>
+        [Pure]
+        public string Inspection => "null";
 
         public override int GetHashCode() => 0;
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Version 0.4.0
 
 To be released.
 
+ -  Removed `Bencodex.Types.CommonVariables` static class.
+
 
 Version 0.3.0
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Version 0.4.0
 
 To be released.
 
+ -  Added `IValue.EncodingLength` property.
  -  Removed `Bencodex.Types.CommonVariables` static class.
 
 


### PR DESCRIPTION
In order to determine the number of encoded bytes of `IValue`s without actually encoding them, the `IValue.EncodingLength` property was introduced.