### PR TITLE
Fingerprinting values for efficient tree comparison

### DIFF
--- a/Bencodex.Tests/CodecTest.cs
+++ b/Bencodex.Tests/CodecTest.cs
@@ -22,7 +22,9 @@ namespace Bencodex.Tests
             Codec codec = new Codec();
             IValue decoded = codec.Decode(spec.Encoding);
             Assert.Equal(spec.Semantics, decoded);
-            Assert.Equal(spec.Encoding.Length, decoded.EncodingLength);
+            Assert.Equal(spec.Encoding.LongLength, decoded.EncodingLength);
+            Assert.Equal(spec.Semantics.EncodingLength, decoded.EncodingLength);
+            Assert.Equal(spec.Semantics.Fingerprint, decoded.Fingerprint);
         }
     }
 }

--- a/Bencodex.Tests/Extensions.cs
+++ b/Bencodex.Tests/Extensions.cs
@@ -1,11 +1,19 @@
+using System;
 using System.Diagnostics.Contracts;
 
-namespace Bencodex.Tests.Types
+namespace Bencodex.Tests
 {
     public static class Extensions
     {
         [Pure]
         public static string NoCr(this string value) =>
             value.Replace("\r", string.Empty);
+
+        public static byte[] NextBytes(this Random random, int size)
+        {
+            var buffer = new byte[size];
+            random.NextBytes(buffer);
+            return buffer;
+        }
     }
 }

--- a/Bencodex.Tests/Misc/FingerprintComparerTest.cs
+++ b/Bencodex.Tests/Misc/FingerprintComparerTest.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.Text;
+using Bencodex.Misc;
+using Bencodex.Types;
+using Xunit;
+using static Bencodex.Misc.ImmutableByteArrayExtensions;
+using F = Bencodex.Types.Fingerprint;
+using T = Bencodex.Types.ValueType;
+
+namespace Bencodex.Tests.Misc
+{
+    public class FingerprintComparerTest
+    {
+        [Fact]
+        public void Compare()
+        {
+            var n = new F(T.Null, 1);
+            var f = new F(T.Boolean, 1, new byte[] { 0 });
+            var t = new F(T.Boolean, 1, new byte[] { 1 });
+            var i0 = new F(T.Integer, 3, new byte[] { 0 });
+            var i45 = new F(T.Integer, 4, new byte[] { 45 });
+            var iM123 = new F(T.Integer, 6, new byte[] { 0b10000101 });
+            var b = new F(T.Binary, 2);
+            var bHello = new F(T.Binary, 7, Encoding.ASCII.GetBytes("hello"));
+            var b445 = new F(T.Binary, 449, ParseHex("cd36b370758a259b34845084a6cc38473cb95e27"));
+            var u = new F(T.Text, 3);
+            var uNihao = new F(T.Text, 9, new byte[] { 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd });
+            var u42 = new F(T.Text, 46, ParseHex("e72dcfd0ae50a80aaa8c1a78b27e2e11bef66488"));
+            var l = new F(T.List, 2);
+            var l1 = new F(T.List, 3, ParseHex("ae7fca60943c2ef2f6cf5420477da41acf29b01d"));
+            var l2 = new F(T.List, 18, ParseHex("22852139f287a01cdb803fd86ed70e4c4d121254"));
+            var lNest = new F(T.List, 26, ParseHex("24caa983a5225522ca798be3b31a1abecdb36fe5"));
+            var d = new F(T.Dictionary, 2);
+            var d1 = new F(T.Dictionary, 14, ParseHex("9312bb9fe32ec11b4e6478f557ea821b0c44523d"));
+            var unordered = new List<Fingerprint>
+            {
+                lNest, l2, u, n, bHello, i0, l1, uNihao,
+                d1, f, iM123, d, b445, l, i45, t, u42, b,
+            };
+            unordered.Sort(new FingerprintComparer());
+            Fingerprint[] ordered =
+            {
+                n, f, t, i0, i45, iM123, b, bHello, b445,
+                u, uNihao, u42, l, l1, l2, lNest, d, d1,
+            };
+            Assert.Equal(ordered, unordered);
+        }
+    }
+}

--- a/Bencodex.Tests/Misc/ImmutableByteArrayExtensionsTest.cs
+++ b/Bencodex.Tests/Misc/ImmutableByteArrayExtensionsTest.cs
@@ -1,0 +1,32 @@
+﻿using Bencodex.Misc;
+using Xunit;
+using static System.Collections.Immutable.ImmutableArray;
+using static Bencodex.Misc.ImmutableByteArrayExtensions;
+
+namespace Bencodex.Tests.Misc
+{
+    public class ImmutableByteArrayExtensionsTest
+    {
+        [Fact]
+        public void Hex()
+        {
+            Assert.Equal("00000000", Create<byte>(0, 0, 0, 0).Hex());
+            Assert.Equal("ffffffffff", Create<byte>(0xff, 0xff, 0xff, 0xff, 0xff).Hex());
+            Assert.Equal(
+                "abbcdef01234567890",
+                Create<byte>(0xab, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78, 0x90).Hex()
+            );
+        }
+
+        [Fact]
+        public void ParseHex_()
+        {
+            Assert.Equal(new byte[4], ParseHex("00000000"));
+            Assert.Equal(new byte[] { 0xff, 0xff, 0xff, 0xff, 0xff }, ParseHex("ffffffffff"));
+            Assert.Equal(
+                new byte[] { 0xab, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78, 0x90 },
+                ParseHex("abbcdef01234567890")
+            );
+        }
+    }
+}

--- a/Bencodex.Tests/Types/BinaryTest.cs
+++ b/Bencodex.Tests/Types/BinaryTest.cs
@@ -56,6 +56,13 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
+        public void Type()
+        {
+            Assert.Equal(ValueType.Binary, _empty.Type);
+            Assert.Equal(ValueType.Binary, _hello.Type);
+        }
+
+        [Fact]
         public void ToByteArray()
         {
             byte[] a = _hello.ToByteArray();

--- a/Bencodex.Tests/Types/BinaryTest.cs
+++ b/Bencodex.Tests/Types/BinaryTest.cs
@@ -67,8 +67,11 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void Fingerprint()
         {
-            Assert.Equal(new Fingerprint(ValueType.Binary, 2), _empty.Fingerprint);
-            Assert.Equal(new Fingerprint(ValueType.Binary, 7, _hello.ByteArray), _hello.Fingerprint);
+            Assert.Equal(new Fingerprint(ValueType.Binary, 2L), _empty.Fingerprint);
+            Assert.Equal(
+                new Fingerprint(ValueType.Binary, 7L, _hello.ByteArray),
+                _hello.Fingerprint
+            );
 
             var longBin = new Binary(
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor " +
@@ -82,7 +85,7 @@ namespace Bencodex.Tests.Types
             Assert.Equal(
                 new Fingerprint(
                     ValueType.Binary,
-                    449,
+                    449L,
                     ParseHex("cd36b370758a259b34845084a6cc38473cb95e27")
                 ),
                 longBin.Fingerprint
@@ -137,9 +140,9 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void EncodingLength()
         {
-            Assert.Equal(2, _empty.EncodingLength);
-            Assert.Equal(7, _hello.EncodingLength);
-            Assert.Equal(13, new Binary(new byte[10]).EncodingLength);
+            Assert.Equal(2L, _empty.EncodingLength);
+            Assert.Equal(7L, _hello.EncodingLength);
+            Assert.Equal(13L, new Binary(new byte[10]).EncodingLength);
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/BinaryTest.cs
+++ b/Bencodex.Tests/Types/BinaryTest.cs
@@ -2,9 +2,11 @@ using System.Collections.Immutable;
 using System.Text;
 using Bencodex.Types;
 using Xunit;
+using static Bencodex.Misc.ImmutableByteArrayExtensions;
 
 namespace Bencodex.Tests.Types
 {
+    // FIXME: Still some tests remain ValueTests.Binary; they should come here.
     public class BinaryTest
     {
         private Binary _empty;
@@ -41,10 +43,10 @@ namespace Bencodex.Tests.Types
         public void ConstructorTakingByteArray()
         {
             var hello = new Binary(new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f });
-            Assert.Equal(
-                new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f },
-                hello.ToByteArray()
-            );
+            Assert.Equal(_hello, hello);
+
+            var hello2 = new Binary(0x68, 0x65, 0x6c, 0x6c, 0x6f);
+            Assert.Equal(_hello, hello2);
         }
 
         [Fact]
@@ -60,6 +62,31 @@ namespace Bencodex.Tests.Types
         {
             Assert.Equal(ValueType.Binary, _empty.Type);
             Assert.Equal(ValueType.Binary, _hello.Type);
+        }
+
+        [Fact]
+        public void Fingerprint()
+        {
+            Assert.Equal(new Fingerprint(ValueType.Binary, 2), _empty.Fingerprint);
+            Assert.Equal(new Fingerprint(ValueType.Binary, 7, _hello.ByteArray), _hello.Fingerprint);
+
+            var longBin = new Binary(
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor " +
+                "incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis " +
+                "nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. " +
+                "Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore " +
+                "eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, " +
+                "sunt in culpa qui officia deserunt mollit anim id est laborum.",
+                Encoding.UTF8
+            );
+            Assert.Equal(
+                new Fingerprint(
+                    ValueType.Binary,
+                    449,
+                    ParseHex("cd36b370758a259b34845084a6cc38473cb95e27")
+                ),
+                longBin.Fingerprint
+            );
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/BooleanTest.cs
+++ b/Bencodex.Tests/Types/BooleanTest.cs
@@ -13,11 +13,11 @@ namespace Bencodex.Tests.Types
         public void SingletonFingerprints()
         {
             Assert.Equal(
-                new Fingerprint(ValueType.Boolean, 1, new byte[] { 1 }),
+                new Fingerprint(ValueType.Boolean, 1L, new byte[] { 1 }),
                 Boolean.TrueFingerprint
             );
             Assert.Equal(
-                new Fingerprint(ValueType.Boolean, 1, new byte[] { 0 }),
+                new Fingerprint(ValueType.Boolean, 1L, new byte[] { 0 }),
                 Boolean.FalseFingerprint
             );
             Assert.NotEqual(Boolean.FalseFingerprint, Boolean.TrueFingerprint);
@@ -26,8 +26,8 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void Fingerprint()
         {
-            Assert.Equal(new Fingerprint(ValueType.Boolean, 1, new byte[] { 1 }), _t.Fingerprint);
-            Assert.Equal(new Fingerprint(ValueType.Boolean, 1, new byte[] { 0 }), _f.Fingerprint);
+            Assert.Equal(new Fingerprint(ValueType.Boolean, 1L, new byte[] { 1 }), _t.Fingerprint);
+            Assert.Equal(new Fingerprint(ValueType.Boolean, 1L, new byte[] { 0 }), _f.Fingerprint);
         }
     }
 }

--- a/Bencodex.Tests/Types/BooleanTest.cs
+++ b/Bencodex.Tests/Types/BooleanTest.cs
@@ -1,0 +1,33 @@
+﻿using Bencodex.Types;
+using Xunit;
+
+namespace Bencodex.Tests.Types
+{
+    // FIXME: Still some tests remain ValueTests.Boolean; they should come here.
+    public class BooleanTest
+    {
+        private readonly Boolean _t = new Boolean(true);
+        private readonly Boolean _f = new Boolean(false);
+
+        [Fact]
+        public void SingletonFingerprints()
+        {
+            Assert.Equal(
+                new Fingerprint(ValueType.Boolean, 1, new byte[] { 1 }),
+                Boolean.TrueFingerprint
+            );
+            Assert.Equal(
+                new Fingerprint(ValueType.Boolean, 1, new byte[] { 0 }),
+                Boolean.FalseFingerprint
+            );
+            Assert.NotEqual(Boolean.FalseFingerprint, Boolean.TrueFingerprint);
+        }
+
+        [Fact]
+        public void Fingerprint()
+        {
+            Assert.Equal(new Fingerprint(ValueType.Boolean, 1, new byte[] { 1 }), _t.Fingerprint);
+            Assert.Equal(new Fingerprint(ValueType.Boolean, 1, new byte[] { 0 }), _f.Fingerprint);
+        }
+    }
+}

--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using Bencodex.Types;
 using Xunit;
+using ValueType = Bencodex.Types.ValueType;
 
 namespace Bencodex.Tests.Types
 {
@@ -297,6 +298,16 @@ namespace Bencodex.Tests.Types
                 () => dictionary.GetValue<Binary>(listKey));
             Assert.Throws<InvalidCastException>(
                 () => dictionary.GetValue<Text>(listKey));
+        }
+
+        [Fact]
+        public void Type()
+        {
+            Assert.Equal(ValueType.Dictionary, Dictionary.Empty.Type);
+            Assert.Equal(ValueType.Dictionary, Dictionary.Empty.SetItem("foo", "bar").Type);
+            Dictionary binaryKey = Dictionary.Empty
+                .SetItem(Encoding.ASCII.GetBytes("foo"), "bar");
+            Assert.Equal(ValueType.Dictionary, binaryKey.Type);
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -343,16 +343,16 @@ namespace Bencodex.Tests.Types
             Assert.Equal(
                 new Fingerprint(
                     ValueType.Dictionary,
-                    14,
-                    ParseHex("c2f36fbae8a22c841eec717a6e0cec3975b0ee44")
+                    14L,
+                    ParseHex("bb1bbb4428e03722aa5e5ad2e0d70657e328dae1")
                 ),
                 _textKey.Fingerprint
             );
             Assert.Equal(
                 new Fingerprint(
                     ValueType.Dictionary,
-                    13,
-                    ParseHex("4f7a9b59a6b76a46d48eb3d7d60babe31eb5a901")
+                    13L,
+                    ParseHex("0a4571a67289be466635ecc577ac136452d8d532")
                 ),
                 _binaryKey.Fingerprint
             );
@@ -360,7 +360,7 @@ namespace Bencodex.Tests.Types
                 new Fingerprint(
                     ValueType.Dictionary,
                     33,
-                    ParseHex("d7c803acb064e64d4022d2e10895c9410b909e1b")
+                    ParseHex("83f7620e739e4dd9c6443a93eae4ff9132580ff3")
                 ),
                 _mixedKeys.Fingerprint
             );
@@ -369,10 +369,10 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void EncodingLength()
         {
-            Assert.Equal(2, Dictionary.Empty.EncodingLength);
-            Assert.Equal(14, _textKey.EncodingLength);
-            Assert.Equal(13, _binaryKey.EncodingLength);
-            Assert.Equal(33, _mixedKeys.EncodingLength);
+            Assert.Equal(2L, Dictionary.Empty.EncodingLength);
+            Assert.Equal(14L, _textKey.EncodingLength);
+            Assert.Equal(13L, _binaryKey.EncodingLength);
+            Assert.Equal(33L, _mixedKeys.EncodingLength);
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/FingerprintTest.cs
+++ b/Bencodex.Tests/Types/FingerprintTest.cs
@@ -15,13 +15,13 @@ namespace Bencodex.Tests.Types
         {
             var f = new Fingerprint(ValueType.Binary, 5, new byte[] { 1, 2, 3, 4, 5 });
             Assert.Equal(ValueType.Binary, f.Type);
-            Assert.Equal(5, f.EncodingLength);
+            Assert.Equal(5L, f.EncodingLength);
             Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, f.GetDigest());
 
             byte[] hash = new Random().NextBytes(20);
             f = new Fingerprint(ValueType.List, 100, hash);
             Assert.Equal(ValueType.List, f.Type);
-            Assert.Equal(100, f.EncodingLength);
+            Assert.Equal(100L, f.EncodingLength);
             Assert.Equal(hash, f.GetDigest());
         }
 

--- a/Bencodex.Tests/Types/FingerprintTest.cs
+++ b/Bencodex.Tests/Types/FingerprintTest.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization.Formatters.Binary;
+using Bencodex.Types;
+using Xunit;
+using ValueType = Bencodex.Types.ValueType;
+
+namespace Bencodex.Tests.Types
+{
+    public class FingerprintTest
+    {
+        [Fact]
+        public void Constructor()
+        {
+            byte[] hash = new Random().NextBytes(20);
+            var f = new Fingerprint(ValueType.Binary, 10, hash);
+            Assert.Equal(ValueType.Binary, f.Type);
+            Assert.Equal(10, f.EncodingLength);
+            Assert.Equal(hash, f.GetHashArray());
+
+            Assert.Throws<ArgumentException>(
+                () => { new Fingerprint(ValueType.List, 3, new byte[19]); }
+            );
+            Assert.Throws<ArgumentException>(
+                () => { new Fingerprint(ValueType.List, 3, new byte[21]); }
+            );
+        }
+
+        [Fact]
+        public void Hash()
+        {
+            var nullId = new Fingerprint(ValueType.Null, 1);
+            Assert.Empty(nullId.Hash);
+            Assert.Empty(nullId.GetHashArray());
+
+            byte[] hash = new Random().NextBytes(20);
+            var listId = new Fingerprint(ValueType.List, 123, hash);
+            Assert.Equal(hash, listId.Hash);
+            Assert.Equal(hash, listId.GetHashArray());
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            byte[] hashA = new Random().NextBytes(20);
+            var hashB = new byte[hashA.Length];
+            hashA.CopyTo(hashB, 0);
+            hashB[19] = (byte)(hashA[19] >= 0xff ? 0 : hashA[19] + 1);
+            Assert.NotEqual(hashA, hashB);
+
+            var l123A = new Fingerprint(ValueType.List, 123, hashA);
+            Assert.False(l123A.Equals(null));
+            Assert.False(l123A.Equals("other"));
+
+            var l123A_ = new Fingerprint(ValueType.List, 123, hashA.ToImmutableList());
+            Assert.Equal(l123A, l123A_);
+            Assert.True(l123A.Equals((object)l123A_));
+            Assert.Equal(l123A.GetHashCode(), l123A_.GetHashCode());
+
+            var d123A = new Fingerprint(ValueType.Dictionary, 123, hashA);
+            Assert.NotEqual(l123A, d123A);
+            Assert.False(l123A.Equals((object)d123A));
+            Assert.NotEqual(l123A.GetHashCode(), d123A.GetHashCode());
+
+            var l122A = new Fingerprint(ValueType.List, 122, hashA);
+            Assert.NotEqual(l123A, l122A);
+            Assert.False(l123A.Equals((object)l122A));
+            Assert.NotEqual(l123A.GetHashCode(), l122A.GetHashCode());
+
+            var l123B = new Fingerprint(ValueType.List, 123, hashB);
+            Assert.NotEqual(l123A, l123B);
+            Assert.False(l123A.Equals((object)l123B));
+            Assert.NotEqual(l123A.GetHashCode(), l123B.GetHashCode());
+        }
+
+        [Fact]
+        public void Serialize()
+        {
+            var random = new Random();
+            byte[] hash = random.NextBytes(20);
+            var f = new Fingerprint(ValueType.List, 123, hash);
+            Assert.Equal(
+                new Fingerprint(ValueType.List, 123, hash.ToImmutableList()).Serialize(),
+                f.Serialize()
+            );
+            Assert.Equal(f, Fingerprint.Deserialize(f.Serialize()));
+
+            var s = new MemoryStream();
+            var formatter = new BinaryFormatter();
+            formatter.Serialize(s, f);
+            s.Seek(0, SeekOrigin.Begin);
+            Assert.Equal(f, (Fingerprint)formatter.Deserialize(s));
+
+            hash = random.NextBytes(20);
+            f = new Fingerprint(ValueType.Dictionary, 456, hash);
+            Assert.Equal(f, Fingerprint.Deserialize(f.Serialize()));
+
+            s = new MemoryStream();
+            formatter.Serialize(s, f);
+            s.Seek(0, SeekOrigin.Begin);
+            Assert.Equal(f, (Fingerprint)formatter.Deserialize(s));
+        }
+    }
+}

--- a/Bencodex.Tests/Types/IntegerTest.cs
+++ b/Bencodex.Tests/Types/IntegerTest.cs
@@ -1,0 +1,42 @@
+﻿using System.Globalization;
+using System.Numerics;
+using Bencodex.Types;
+using Xunit;
+using static Bencodex.Misc.ImmutableByteArrayExtensions;
+using ValueType = Bencodex.Types.ValueType;
+
+namespace Bencodex.Tests.Types
+{
+    // FIXME: Still some tests remain ValueTests.Integer; they should come here.
+    public class IntegerTest
+    {
+        [Fact]
+        public void Fingerprint()
+        {
+            Assert.Equal(
+                new Fingerprint(ValueType.Integer, 3, new byte[] { 0 }),
+                new Integer(0).Fingerprint
+            );
+            Assert.Equal(
+                new Fingerprint(ValueType.Integer, 4, new byte[] { 45 }),
+                new Integer(45).Fingerprint
+            );
+            Assert.Equal(
+                new Fingerprint(ValueType.Integer, 6, new byte[] { 0b10000101 }),
+                new Integer(-123).Fingerprint
+            );
+            BigInteger bigint = BigInteger.Parse(
+                "10000000000000000000000000000000000000000",
+                NumberStyles.HexNumber
+            );
+            Assert.Equal(
+                new Fingerprint(
+                    ValueType.Integer,
+                    51,
+                    ParseHex("8209ad2f4fad401d8e3d33def02577bd9ab550e5")
+                ),
+                new Integer(bigint).Fingerprint
+            );
+        }
+    }
+}

--- a/Bencodex.Tests/Types/IntegerTest.cs
+++ b/Bencodex.Tests/Types/IntegerTest.cs
@@ -14,15 +14,15 @@ namespace Bencodex.Tests.Types
         public void Fingerprint()
         {
             Assert.Equal(
-                new Fingerprint(ValueType.Integer, 3, new byte[] { 0 }),
+                new Fingerprint(ValueType.Integer, 3L, new byte[] { 0 }),
                 new Integer(0).Fingerprint
             );
             Assert.Equal(
-                new Fingerprint(ValueType.Integer, 4, new byte[] { 45 }),
+                new Fingerprint(ValueType.Integer, 4L, new byte[] { 45 }),
                 new Integer(45).Fingerprint
             );
             Assert.Equal(
-                new Fingerprint(ValueType.Integer, 6, new byte[] { 0b10000101 }),
+                new Fingerprint(ValueType.Integer, 6L, new byte[] { 0b10000101 }),
                 new Integer(-123).Fingerprint
             );
             BigInteger bigint = BigInteger.Parse(
@@ -32,7 +32,7 @@ namespace Bencodex.Tests.Types
             Assert.Equal(
                 new Fingerprint(
                     ValueType.Integer,
-                    51,
+                    51L,
                     ParseHex("8209ad2f4fad401d8e3d33def02577bd9ab550e5")
                 ),
                 new Integer(bigint).Fingerprint

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -1,7 +1,9 @@
 using System.Linq;
 using System.Text;
+using Bencodex.Misc;
 using Bencodex.Types;
 using Xunit;
+using static Bencodex.Misc.ImmutableByteArrayExtensions;
 
 namespace Bencodex.Tests.Types
 {
@@ -35,6 +37,39 @@ namespace Bencodex.Tests.Types
             Assert.Equal(ValueType.List, _one.Type);
             Assert.Equal(ValueType.List, _two.Type);
             Assert.Equal(ValueType.List, _nest.Type);
+        }
+
+        [Fact]
+        public void Fingerprint()
+        {
+            Assert.Equal(
+                new Fingerprint(ValueType.List, 2),
+                _zero.Fingerprint
+            );
+            Assert.Equal(
+                new Fingerprint(
+                    ValueType.List,
+                    3,
+                    ParseHex("ae7fca60943c2ef2f6cf5420477da41acf29b01d")
+                ),
+                _one.Fingerprint
+            );
+            Assert.Equal(
+                new Fingerprint(
+                    ValueType.List,
+                    18,
+                    ParseHex("22852139f287a01cdb803fd86ed70e4c4d121254")
+                ),
+                _two.Fingerprint
+            );
+            Assert.Equal(
+                new Fingerprint(
+                    ValueType.List,
+                    26,
+                    ParseHex("24caa983a5225522ca798be3b31a1abecdb36fe5")
+                ),
+                _nest.Fingerprint
+            );
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -43,30 +43,30 @@ namespace Bencodex.Tests.Types
         public void Fingerprint()
         {
             Assert.Equal(
-                new Fingerprint(ValueType.List, 2),
+                new Fingerprint(ValueType.List, 2L),
                 _zero.Fingerprint
             );
             Assert.Equal(
                 new Fingerprint(
                     ValueType.List,
-                    3,
-                    ParseHex("ae7fca60943c2ef2f6cf5420477da41acf29b01d")
+                    3L,
+                    ParseHex("d14952314d5de233ef0dd0a178617f7f07ea082c")
                 ),
                 _one.Fingerprint
             );
             Assert.Equal(
                 new Fingerprint(
                     ValueType.List,
-                    18,
-                    ParseHex("22852139f287a01cdb803fd86ed70e4c4d121254")
+                    18L,
+                    ParseHex("16a855873ac787b7c7f2d2d0360119ca4cbb66fe")
                 ),
                 _two.Fingerprint
             );
             Assert.Equal(
                 new Fingerprint(
                     ValueType.List,
-                    26,
-                    ParseHex("24caa983a5225522ca798be3b31a1abecdb36fe5")
+                    26L,
+                    ParseHex("82daa9e2ff9f01393b718e09ab9fddd9f8c04e2b")
                 ),
                 _nest.Fingerprint
             );
@@ -75,10 +75,10 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void EncodingLength()
         {
-            Assert.Equal(2, _zero.EncodingLength);
-            Assert.Equal(3, _one.EncodingLength);
-            Assert.Equal(18, _two.EncodingLength);
-            Assert.Equal(26, _nest.EncodingLength);
+            Assert.Equal(2L, _zero.EncodingLength);
+            Assert.Equal(3L, _one.EncodingLength);
+            Assert.Equal(18L, _two.EncodingLength);
+            Assert.Equal(26L, _nest.EncodingLength);
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -29,6 +29,15 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
+        public void Type()
+        {
+            Assert.Equal(ValueType.List, _zero.Type);
+            Assert.Equal(ValueType.List, _one.Type);
+            Assert.Equal(ValueType.List, _two.Type);
+            Assert.Equal(ValueType.List, _nest.Type);
+        }
+
+        [Fact]
         public void EncodingLength()
         {
             Assert.Equal(2, _zero.EncodingLength);

--- a/Bencodex.Tests/Types/NullTest.cs
+++ b/Bencodex.Tests/Types/NullTest.cs
@@ -3,12 +3,25 @@ using Xunit;
 
 namespace Bencodex.Tests.Types
 {
+    // FIXME: Still some tests remain ValueTests.Null; they should come here.
     public class NullTest
     {
         [Fact]
         public void Value()
         {
             Assert.IsType<Null>(Null.Value);
+        }
+
+        [Fact]
+        public void SingletonFingerprint()
+        {
+            Assert.Equal(new Fingerprint(ValueType.Null, 1), Null.SingletonFingerprint);
+        }
+
+        [Fact]
+        public void Fingerprint()
+        {
+            Assert.Equal(new Fingerprint(ValueType.Null, 1), Null.Value.Fingerprint);
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/NullTest.cs
+++ b/Bencodex.Tests/Types/NullTest.cs
@@ -15,19 +15,19 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void SingletonFingerprint()
         {
-            Assert.Equal(new Fingerprint(ValueType.Null, 1), Null.SingletonFingerprint);
+            Assert.Equal(new Fingerprint(ValueType.Null, 1L), Null.SingletonFingerprint);
         }
 
         [Fact]
         public void Fingerprint()
         {
-            Assert.Equal(new Fingerprint(ValueType.Null, 1), Null.Value.Fingerprint);
+            Assert.Equal(new Fingerprint(ValueType.Null, 1L), Null.Value.Fingerprint);
         }
 
         [Fact]
         public void EncodingLength()
         {
-            Assert.Equal(1, Null.Value.EncodingLength);
+            Assert.Equal(1L, Null.Value.EncodingLength);
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/NullTest.cs
+++ b/Bencodex.Tests/Types/NullTest.cs
@@ -10,5 +10,17 @@ namespace Bencodex.Tests.Types
         {
             Assert.IsType<Null>(Null.Value);
         }
+
+        [Fact]
+        public void EncodingLength()
+        {
+            Assert.Equal(1, Null.Value.EncodingLength);
+        }
+
+        [Fact]
+        public void Type()
+        {
+            Assert.Equal(ValueType.Null, Null.Value.Type);
+        }
     }
 }

--- a/Bencodex.Tests/Types/TextTest.cs
+++ b/Bencodex.Tests/Types/TextTest.cs
@@ -1,0 +1,36 @@
+﻿using Bencodex.Types;
+using Xunit;
+using static Bencodex.Misc.ImmutableByteArrayExtensions;
+
+namespace Bencodex.Tests.Types
+{
+    // FIXME: Still some tests remain ValueTests.UnicodeText; they should come here.
+    public class TextTest
+    {
+        private readonly Text _empty = default(Text);
+        private readonly Text _nihao = new Text("\u4f60\u597d");
+        private readonly Text _complex = new Text("new lines and\n\"quotes\" become escaped to \\");
+
+        [Fact]
+        public void Fingerprint()
+        {
+            Assert.Equal(new Fingerprint(ValueType.Text, 3), _empty.Fingerprint);
+            Assert.Equal(
+                new Fingerprint(
+                    ValueType.Text,
+                    9,
+                    new byte[] { 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd }
+                ),
+                _nihao.Fingerprint
+            );
+            Assert.Equal(
+                new Fingerprint(
+                    ValueType.Text,
+                    46,
+                    ParseHex("e72dcfd0ae50a80aaa8c1a78b27e2e11bef66488")
+                ),
+                _complex.Fingerprint
+            );
+        }
+    }
+}

--- a/Bencodex.Tests/Types/TextTest.cs
+++ b/Bencodex.Tests/Types/TextTest.cs
@@ -14,11 +14,11 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void Fingerprint()
         {
-            Assert.Equal(new Fingerprint(ValueType.Text, 3), _empty.Fingerprint);
+            Assert.Equal(new Fingerprint(ValueType.Text, 3L), _empty.Fingerprint);
             Assert.Equal(
                 new Fingerprint(
                     ValueType.Text,
-                    9,
+                    9L,
                     new byte[] { 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd }
                 ),
                 _nihao.Fingerprint
@@ -26,7 +26,7 @@ namespace Bencodex.Tests.Types
             Assert.Equal(
                 new Fingerprint(
                     ValueType.Text,
-                    46,
+                    46L,
                     ParseHex("e72dcfd0ae50a80aaa8c1a78b27e2e11bef66488")
                 ),
                 _complex.Fingerprint

--- a/Bencodex.Tests/Types/ValueTests.cs
+++ b/Bencodex.Tests/Types/ValueTests.cs
@@ -7,28 +7,33 @@ using System.Numerics;
 using System.Text;
 using Bencodex.Types;
 using Xunit;
+using Xunit.Abstractions;
 using ValueType = Bencodex.Types.ValueType;
 
 namespace Bencodex.Tests.Types
 {
     public class ValueTests
     {
-        private Codec _codec;
+        private readonly ITestOutputHelper _output;
+        private readonly Codec _codec;
 
-        public ValueTests()
+        public ValueTests(ITestOutputHelper output)
         {
+            _output = output;
             _codec = new Codec();
         }
 
         [Fact]
         public void Null()
         {
+            // FIXME: Move to NullTest.
             AssertEqual(
                 new byte[] { 0x6e },  // "n"
                 _codec.Encode(default(Null))
             );
 
             Assert.Equal(ValueType.Null, default(Null).Type);
+            Assert.Equal(new Fingerprint(ValueType.Null, 1), default(Null).Fingerprint);
             Assert.Equal(1, default(Null).EncodingLength);
             Assert.Equal("null", default(Null).Inspection);
             Assert.Equal("Bencodex.Types.Null", default(Null).ToString());
@@ -37,6 +42,7 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void Boolean()
         {
+            // FIXME: Move to BooleanTest.
             var t = new Bencodex.Types.Boolean(true);
             var f = new Bencodex.Types.Boolean(false);
             AssertEqual(
@@ -50,6 +56,8 @@ namespace Bencodex.Tests.Types
 
             Assert.Equal(ValueType.Boolean, t.Type);
             Assert.Equal(ValueType.Boolean, f.Type);
+            Assert.Equal(new Fingerprint(ValueType.Boolean, 1, new byte[] { 1 }), t.Fingerprint);
+            Assert.Equal(new Fingerprint(ValueType.Boolean, 1, new byte[] { 0 }), f.Fingerprint);
             Assert.Equal(1, t.EncodingLength);
             Assert.Equal(1, f.EncodingLength);
             Assert.Equal("true", t.Inspection);
@@ -61,6 +69,7 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void Integer()
         {
+            // FIXME: Move to IntegerTest.
             IntegerGeneric(i => new Integer((short)i));
             IntegerGeneric(
                 i => i >= 0 ? new Integer((ushort)i) : (Integer?)null
@@ -93,6 +102,7 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void Binary()
         {
+            // FIXME: Move to BinaryTest.
             var empty = default(Binary);
             var hello = new Binary(new byte[] { 0x68, 0x65, 0x6c, 0x6c, 0x6f });
 
@@ -109,6 +119,7 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void UnicodeText()
         {
+            // FIXME: Move to TextTest.
             var empty = default(Text);
             var nihao = new Text("\u4f60\u597d");
 
@@ -148,6 +159,7 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void List()
         {
+            // FIXME: Move to ListTest.
             var zero = default(List);
             var two = new List(new Text[] { "hello", "world" }.Cast<IValue>());
 
@@ -178,6 +190,7 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void Dictionary()
         {
+            // FIXME: Move to DictionaryTest.
             AssertEqual(
                 new byte[] { 0x64, 0x65 },  // "de"
                 _codec.Encode(
@@ -220,11 +233,14 @@ namespace Bencodex.Tests.Types
         [ClassData(typeof(SpecTheoryData))]
         public void SpecTestSuite(Spec spec)
         {
+            _output.WriteLine("YAML: {0}", spec.SemanticsPath);
+            _output.WriteLine("Data: {0}", spec.EncodingPath);
             AssertEqual(
                 spec.Encoding,
                 _codec.Encode(spec.Semantics),
                 spec.SemanticsPath
             );
+            Assert.Equal(spec.Encoding.Length, spec.Semantics.EncodingLength);
         }
 
         private void IntegerGeneric(Func<int, Integer?> convert)

--- a/Bencodex.Tests/Types/ValueTests.cs
+++ b/Bencodex.Tests/Types/ValueTests.cs
@@ -34,7 +34,7 @@ namespace Bencodex.Tests.Types
 
             Assert.Equal(ValueType.Null, default(Null).Type);
             Assert.Equal(new Fingerprint(ValueType.Null, 1), default(Null).Fingerprint);
-            Assert.Equal(1, default(Null).EncodingLength);
+            Assert.Equal(1L, default(Null).EncodingLength);
             Assert.Equal("null", default(Null).Inspection);
             Assert.Equal("Bencodex.Types.Null", default(Null).ToString());
         }
@@ -58,8 +58,8 @@ namespace Bencodex.Tests.Types
             Assert.Equal(ValueType.Boolean, f.Type);
             Assert.Equal(new Fingerprint(ValueType.Boolean, 1, new byte[] { 1 }), t.Fingerprint);
             Assert.Equal(new Fingerprint(ValueType.Boolean, 1, new byte[] { 0 }), f.Fingerprint);
-            Assert.Equal(1, t.EncodingLength);
-            Assert.Equal(1, f.EncodingLength);
+            Assert.Equal(1L, t.EncodingLength);
+            Assert.Equal(1L, f.EncodingLength);
             Assert.Equal("true", t.Inspection);
             Assert.Equal("false", f.Inspection);
             Assert.Equal("Bencodex.Types.Boolean true", t.ToString());
@@ -90,9 +90,9 @@ namespace Bencodex.Tests.Types
             Assert.Equal(ValueType.Integer, new Integer(0).Type);
             Assert.Equal(ValueType.Integer, new Integer(123).Type);
             Assert.Equal(ValueType.Integer, new Integer(-456).Type);
-            Assert.Equal(3, new Integer(0).EncodingLength);
-            Assert.Equal(5, new Integer(123).EncodingLength);
-            Assert.Equal(6, new Integer(-456).EncodingLength);
+            Assert.Equal(3L, new Integer(0).EncodingLength);
+            Assert.Equal(5L, new Integer(123).EncodingLength);
+            Assert.Equal(6L, new Integer(-456).EncodingLength);
             Assert.Equal("123", new Integer(123).Inspection);
             Assert.Equal("-456", new Integer(-456).Inspection);
             Assert.Equal("Bencodex.Types.Integer 123", new Integer(123).ToString());
@@ -143,9 +143,9 @@ namespace Bencodex.Tests.Types
             Assert.Equal(ValueType.Text, empty.Type);
             Assert.Equal(ValueType.Text, nihao.Type);
             Assert.Equal(ValueType.Text, complex.Type);
-            Assert.Equal(3, empty.EncodingLength);
-            Assert.Equal(9, nihao.EncodingLength);
-            Assert.Equal(46, complex.EncodingLength);
+            Assert.Equal(3L, empty.EncodingLength);
+            Assert.Equal(9L, nihao.EncodingLength);
+            Assert.Equal(46L, complex.EncodingLength);
             Assert.Equal("\"\"", empty.Inspection);
             Assert.Equal("\"\u4f60\u597d\"", nihao.Inspection);
             Assert.Equal(
@@ -240,7 +240,7 @@ namespace Bencodex.Tests.Types
                 _codec.Encode(spec.Semantics),
                 spec.SemanticsPath
             );
-            Assert.Equal(spec.Encoding.Length, spec.Semantics.EncodingLength);
+            Assert.Equal(spec.Encoding.LongLength, spec.Semantics.EncodingLength);
         }
 
         private void IntegerGeneric(Func<int, Integer?> convert)

--- a/Bencodex.Tests/Types/ValueTests.cs
+++ b/Bencodex.Tests/Types/ValueTests.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Globalization;
@@ -8,7 +7,7 @@ using System.Numerics;
 using System.Text;
 using Bencodex.Types;
 using Xunit;
-using Xunit.Abstractions;
+using ValueType = Bencodex.Types.ValueType;
 
 namespace Bencodex.Tests.Types
 {
@@ -29,6 +28,7 @@ namespace Bencodex.Tests.Types
                 _codec.Encode(default(Null))
             );
 
+            Assert.Equal(ValueType.Null, default(Null).Type);
             Assert.Equal(1, default(Null).EncodingLength);
             Assert.Equal("null", default(Null).Inspection);
             Assert.Equal("Bencodex.Types.Null", default(Null).ToString());
@@ -48,6 +48,8 @@ namespace Bencodex.Tests.Types
                 _codec.Encode(f)
             );
 
+            Assert.Equal(ValueType.Boolean, t.Type);
+            Assert.Equal(ValueType.Boolean, f.Type);
             Assert.Equal(1, t.EncodingLength);
             Assert.Equal(1, f.EncodingLength);
             Assert.Equal("true", t.Inspection);
@@ -76,6 +78,9 @@ namespace Bencodex.Tests.Types
             var locale = new CultureInfo("ar-SA");
             IntegerGeneric(i => new Integer(i.ToString(locale), locale));
 
+            Assert.Equal(ValueType.Integer, new Integer(0).Type);
+            Assert.Equal(ValueType.Integer, new Integer(123).Type);
+            Assert.Equal(ValueType.Integer, new Integer(-456).Type);
             Assert.Equal(3, new Integer(0).EncodingLength);
             Assert.Equal(5, new Integer(123).EncodingLength);
             Assert.Equal(6, new Integer(-456).EncodingLength);
@@ -124,6 +129,9 @@ namespace Bencodex.Tests.Types
 
             var complex = new Text("new lines and\n\"quotes\" become escaped to \\");
 
+            Assert.Equal(ValueType.Text, empty.Type);
+            Assert.Equal(ValueType.Text, nihao.Type);
+            Assert.Equal(ValueType.Text, complex.Type);
             Assert.Equal(3, empty.EncodingLength);
             Assert.Equal(9, nihao.EncodingLength);
             Assert.Equal(46, complex.EncodingLength);

--- a/Bencodex/Misc/FingerprintComparer.cs
+++ b/Bencodex/Misc/FingerprintComparer.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using Bencodex.Types;
+
+namespace Bencodex.Misc
+{
+    /// <summary>
+    /// Compares two <see cref="Fingerprint"/> values.  There is no meaning for the order,
+    /// but it just purposes to make the order deterministic.
+    /// </summary>
+    public sealed class FingerprintComparer : IComparer<Fingerprint>
+    {
+        private static readonly ByteArrayComparer _digestComparer = default;
+
+        /// <inheritdoc cref="IComparer{T}.Compare(T, T)"/>
+        public int Compare(Fingerprint x, Fingerprint y)
+        {
+            if (x.Type != y.Type)
+            {
+                return x.Type < y.Type ? -1 : 1;
+            }
+
+            int encLenCmp = x.EncodingLength.CompareTo(y.EncodingLength);
+            return encLenCmp != 0 ? encLenCmp : _digestComparer.Compare(x.Digest, y.Digest);
+        }
+    }
+}

--- a/Bencodex/Misc/ImmutableByteArrayExtensions.cs
+++ b/Bencodex/Misc/ImmutableByteArrayExtensions.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.Text;
+
+namespace Bencodex.Misc
+{
+    /// <summary>
+    /// Extension methods on <see cref="ImmutableArray{T}"/> of <see cref="byte"/>s.
+    /// </summary>
+    public static class ImmutableByteArrayExtensions
+    {
+        /// <summary>
+        /// Converts the given <paramref name="bytes"/> into a string of hexadecimal digits.
+        /// </summary>
+        /// <param name="bytes">The byte array to convert.</param>
+        /// <returns>The hexadecimal digits.  Alphabets are all lowercase.</returns>
+        public static string Hex(this in ImmutableArray<byte> bytes)
+        {
+            const string hexDigits = "0123456789abcdef";
+            var s = new StringBuilder(bytes.Length * 2);
+            foreach (var b in bytes)
+            {
+                s.Append(hexDigits[b >> 4]);
+                s.Append(hexDigits[b & 0xf]);
+            }
+
+            return s.ToString();
+        }
+
+        /// <summary>
+        /// Parses the given <paramref name="hex"/> string into the bytes.
+        /// </summary>
+        /// <param name="hex">The hexadecimal digits to convert.</param>
+        /// <returns>The converted byte array.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when the length of
+        /// <paramref name="hex"/> string is an odd number.</exception>
+        /// <exception cref="FormatException">Thrown when the <paramref name="hex"/>
+        /// string contains non-hexadecimal digits.</exception>
+        public static ImmutableArray<byte> ParseHex(string hex)
+        {
+            if (hex.Length % 2 > 0)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(hex),
+                    "A length of a hexadecimal string must be an even number."
+                );
+            }
+
+            var bytes = ImmutableArray.CreateBuilder<byte>(hex.Length / 2);
+            for (var i = 0; i < hex.Length / 2; i++)
+            {
+                bytes.Add(Convert.ToByte(hex.Substring(i * 2, 2), 16));
+            }
+
+            return bytes.MoveToImmutable();
+        }
+    }
+}

--- a/Bencodex/Types/Binary.cs
+++ b/Bencodex/Types/Binary.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
 using Bencodex.Misc;
 
@@ -27,16 +28,18 @@ namespace Bencodex.Types
 
         private readonly ImmutableArray<byte> _value;
         private readonly int?[] _hashCode;
+        private readonly ImmutableArray<byte>?[] _digest;
 
         public Binary(ImmutableArray<byte> value)
         {
             _value = value;
             _hashCode = new int?[1];
+            _digest = new[] { (ImmutableArray<byte>?)null };
         }
 
-        public Binary(byte[] value)
+        public Binary(params byte[] value)
             : this(value is byte[] bytes
-                ? ImmutableArray.Create<byte>(bytes)
+                ? ImmutableArray.Create(bytes)
                 : throw new ArgumentNullException(nameof(value)))
         {
         }
@@ -60,6 +63,23 @@ namespace Bencodex.Types
         /// <inheritdoc cref="IValue.Type"/>
         [Pure]
         public ValueType Type => ValueType.Binary;
+
+        /// <inheritdoc cref="IValue.Fingerprint"/>
+        [Pure]
+        public Fingerprint Fingerprint
+        {
+            get
+            {
+                ImmutableArray<byte> digest = _digest is { } cache
+                    ? cache[0] is { } b
+                        ? b
+                        : ByteArray.Length > 20
+                            ? ImmutableArray.Create(SHA1.Create().ComputeHash(ToByteArray()))
+                            : ByteArray
+                    : ImmutableArray<byte>.Empty;
+                return new Fingerprint(Type, EncodingLength, digest);
+            }
+        }
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]

--- a/Bencodex/Types/Binary.cs
+++ b/Bencodex/Types/Binary.cs
@@ -83,9 +83,9 @@ namespace Bencodex.Types
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
-        public int EncodingLength =>
+        public long EncodingLength =>
             ByteArray.Length.ToString(CultureInfo.InvariantCulture).Length +
-            CommonVariables.Separator.Length +
+            CommonVariables.Separator.LongLength +
             ByteArray.Length;
 
         /// <inheritdoc cref="IValue.Inspection"/>

--- a/Bencodex/Types/Binary.cs
+++ b/Bencodex/Types/Binary.cs
@@ -57,6 +57,10 @@ namespace Bencodex.Types
             "method or Binary.ByteArray property instead.")]
         public byte[] Value => ToByteArray();
 
+        /// <inheritdoc cref="IValue.Type"/>
+        [Pure]
+        public ValueType Type => ValueType.Binary;
+
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
         public int EncodingLength =>

--- a/Bencodex/Types/Boolean.cs
+++ b/Bencodex/Types/Boolean.cs
@@ -26,6 +26,10 @@ namespace Bencodex.Types
 
         public bool Value { get; }
 
+        /// <inheritdoc cref="IValue.Type"/>
+        [Pure]
+        public ValueType Type => ValueType.Boolean;
+
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
         public int EncodingLength => 1;

--- a/Bencodex/Types/Boolean.cs
+++ b/Bencodex/Types/Boolean.cs
@@ -19,6 +19,14 @@ namespace Bencodex.Types
 
         private static readonly byte[] _false = new byte[1] { 0x66 };  // 'f'
 
+#pragma warning disable SA1202
+        public static readonly Fingerprint TrueFingerprint =
+            new Fingerprint(ValueType.Boolean, 1, new byte[] { 1 });
+
+        public static readonly Fingerprint FalseFingerprint =
+            new Fingerprint(ValueType.Boolean, 1, new byte[] { 0 });
+#pragma warning restore SA1202
+
         public Boolean(bool value)
         {
             Value = value;
@@ -29,6 +37,10 @@ namespace Bencodex.Types
         /// <inheritdoc cref="IValue.Type"/>
         [Pure]
         public ValueType Type => ValueType.Boolean;
+
+        /// <inheritdoc cref="IValue.Fingerprint"/>
+        [Pure]
+        public Fingerprint Fingerprint => Value ? TrueFingerprint : FalseFingerprint;
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]

--- a/Bencodex/Types/Boolean.cs
+++ b/Bencodex/Types/Boolean.cs
@@ -21,10 +21,10 @@ namespace Bencodex.Types
 
 #pragma warning disable SA1202
         public static readonly Fingerprint TrueFingerprint =
-            new Fingerprint(ValueType.Boolean, 1, new byte[] { 1 });
+            new Fingerprint(ValueType.Boolean, 1L, new byte[] { 1 });
 
         public static readonly Fingerprint FalseFingerprint =
-            new Fingerprint(ValueType.Boolean, 1, new byte[] { 0 });
+            new Fingerprint(ValueType.Boolean, 1L, new byte[] { 0 });
 #pragma warning restore SA1202
 
         public Boolean(bool value)
@@ -44,7 +44,7 @@ namespace Bencodex.Types
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
-        public int EncodingLength => 1;
+        public long EncodingLength => 1L;
 
         /// <inheritdoc cref="IValue.Inspection"/>
         [Pure]

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -93,7 +93,7 @@ namespace Bencodex.Types
 
                 if (!(v.Hash is { } hash))
                 {
-                    int encLength = 2;
+                    long encLength = 2L;
                     SHA1 sha1 = SHA1.Create();
                     sha1.Initialize();
                     foreach (KeyValuePair<Fingerprint, Fingerprint> pair in fDict)
@@ -121,14 +121,14 @@ namespace Bencodex.Types
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
-        public int EncodingLength =>
+        public long EncodingLength =>
             _value is { } v
                 ? v.EncodingLength >= 0
                     ? v.EncodingLength
-                    : v.EncodingLength = _dictionaryPrefix.Length
+                    : v.EncodingLength = _dictionaryPrefix.LongLength
                         + Value.Sum(kv => kv.Key.EncodingLength + kv.Value.EncodingLength)
-                        + CommonVariables.Suffix.Length
-                : 2;
+                        + CommonVariables.Suffix.LongLength
+                : 2L;
 
         /// <inheritdoc cref="IValue.Inspection"/>
         [Pure]
@@ -453,7 +453,7 @@ namespace Bencodex.Types
         public IEnumerable<byte[]> EncodeIntoChunks()
         {
             // FIXME: avoid duplication between this and EncodeToStream()
-            int length = _dictionaryPrefix.Length;
+            long length = _dictionaryPrefix.LongLength;
             yield return _dictionaryPrefix;
 
             if (!(_value is null))
@@ -488,22 +488,22 @@ namespace Bencodex.Types
                     if (keyPrefix != null)
                     {
                         yield return _unicodeKeyPrefix;
-                        length += _unicodeKeyPrefix.Length;
+                        length += _unicodeKeyPrefix.LongLength;
                     }
 
                     byte[] keyLengthBytes = Encoding.ASCII.GetBytes(
                         key.Length.ToString(CultureInfo.InvariantCulture)
                     );
                     yield return keyLengthBytes;
-                    length += keyLengthBytes.Length;
+                    length += keyLengthBytes.LongLength;
                     yield return CommonVariables.Separator;
-                    length += CommonVariables.Separator.Length;
+                    length += CommonVariables.Separator.LongLength;
                     yield return key;
-                    length += key.Length;
+                    length += key.LongLength;
                     foreach (byte[] chunk in value.EncodeIntoChunks())
                     {
                         yield return chunk;
-                        length += chunk.Length;
+                        length += chunk.LongLength;
                     }
 
                     prev = (keyPrefix, key);
@@ -572,7 +572,7 @@ namespace Bencodex.Types
             stream.WriteByte(CommonVariables.Suffix[0]);
             if (_value is { } v)
             {
-                v.EncodingLength = (int)(stream.Position - startPos);
+                v.EncodingLength = stream.Position - startPos;
             }
         }
 
@@ -586,7 +586,7 @@ namespace Bencodex.Types
             internal ImmutableDictionary<IKey, IValue>? Dict;
             internal KeyValuePair<IKey, IValue>[]? Pairs;
             internal ImmutableArray<byte>? Hash;
-            internal int EncodingLength = -1;
+            internal long EncodingLength = -1;
         }
 #pragma warning restore SA1401
     }

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -46,6 +46,10 @@ namespace Bencodex.Types
         public IEnumerable<IValue> Values =>
             Value.Values;
 
+        /// <inheritdoc cref="IValue.Type"/>
+        [Pure]
+        public ValueType Type => ValueType.Dictionary;
+
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
         public int EncodingLength =>

--- a/Bencodex/Types/Fingerprint.cs
+++ b/Bencodex/Types/Fingerprint.cs
@@ -1,0 +1,207 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Diagnostics.Contracts;
+using System.Linq;
+using System.Runtime.Serialization;
+
+namespace Bencodex.Types
+{
+    /// <summary>
+    /// Represents a unique fingerprint of a Bencodex value.
+    /// </summary>
+    [Serializable]
+    public readonly struct Fingerprint : IEquatable<Fingerprint>, ISerializable
+    {
+        private readonly (
+            byte, byte, byte, byte, byte, byte, byte, byte, byte, byte,
+            byte, byte, byte, byte, byte, byte, byte, byte, byte, byte
+        )? _hash;
+
+        /// <summary>
+        /// Creates a <see cref="Fingerprint"/> value.
+        /// </summary>
+        /// <param name="type">The value type.</param>
+        /// <param name="encodingLength">The byte length of encoded value.</param>
+        public Fingerprint(ValueType type, int encodingLength)
+            : this(type, encodingLength, Array.Empty<byte>())
+        {
+        }
+
+        /// <summary>
+        /// Creates a <see cref="Fingerprint"/> value.
+        /// </summary>
+        /// <param name="type">The value type.</param>
+        /// <param name="encodingLength">The byte length of encoded value.</param>
+        /// <param name="hash">The hash digest of the value.  It can be either empty or 20
+        /// bytes.</param>
+        /// <exception cref="ArgumentException">Thrown when the <paramref name="hash"/> size
+        /// is invalid.</exception>
+        public Fingerprint(
+            ValueType type,
+            int encodingLength,
+            IReadOnlyList<byte> hash
+        )
+        {
+            if (hash.Any())
+            {
+                if (hash.Count != 20)
+                {
+                    throw new ArgumentException("The hash must be 20 bytes.", nameof(hash));
+                }
+
+                _hash = (hash[0], hash[1], hash[2], hash[3], hash[4],
+                         hash[5], hash[6], hash[7], hash[8], hash[9],
+                         hash[10], hash[11], hash[12], hash[13], hash[14],
+                         hash[15], hash[16], hash[17], hash[18], hash[19]);
+            }
+            else
+            {
+                _hash = null;
+            }
+
+            Type = type;
+            EncodingLength = encodingLength;
+        }
+
+        private Fingerprint(SerializationInfo info, StreamingContext context)
+            : this(
+                (ValueType)info.GetByte(nameof(Type)),
+                info.GetInt32(nameof(EncodingLength)),
+                (byte[])info.GetValue(nameof(Hash), typeof(byte[]))
+            )
+        {
+        }
+
+        /// <summary>
+        /// The value type.
+        /// </summary>
+        [Pure]
+        public ValueType Type { get; }
+
+        /// <summary>
+        /// The byte length of encoded value.
+        /// </summary>
+        [Pure]
+        public int EncodingLength { get; }
+
+        /// <summary>
+        /// The hash digest of the value.  It can be either empty or 20 bytes.
+        /// </summary>
+        [Pure]
+        public ImmutableArray<byte> Hash => ImmutableArray.Create(GetHashArray());
+
+        /// <summary>
+        /// Deserialized the serialized fingerprint bytes.
+        /// </summary>
+        /// <param name="serialized">The bytes made by <see cref="Serialize()"/> method.</param>
+        /// <returns>The deserialized <see cref="Fingerprint"/> value.</returns>
+        /// <exception cref="FormatException">Thrown when the <paramref name="serialized"/> bytes
+        /// is invalid.</exception>
+        public static Fingerprint Deserialize(byte[] serialized)
+        {
+            byte type;
+            byte[] hash;
+            byte[] encLength;
+            if (serialized.Length >= 1 + 20 + 1)
+            {
+                type = serialized[0];
+                hash = new byte[20];
+                Array.Copy(serialized, 1, hash, 0, 20);
+                encLength = new byte[serialized.Length - 1 - 20];
+                Array.Copy(serialized, 1 + 20, encLength, 0, encLength.Length);
+            }
+            else if (serialized.Length > 1)
+            {
+                type = serialized[0];
+                hash = Array.Empty<byte>();
+                encLength = new byte[serialized.Length - 1];
+                Array.Copy(serialized, 1, encLength, 0, encLength.Length);
+            }
+            else
+            {
+                throw new FormatException("The serialized bytes is not valid.");
+            }
+
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(encLength);
+            }
+
+            return new Fingerprint((ValueType)type, BitConverter.ToInt32(encLength, 0), hash);
+        }
+
+        /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
+        [Pure]
+        public bool Equals(Fingerprint other) =>
+            Type == other.Type &&
+            EncodingLength == other.EncodingLength &&
+            (
+                (_hash is { } h && other._hash is { } o && h.Equals(o)) ||
+                (_hash is null && other._hash is null)
+            );
+
+        /// <inheritdoc cref="object.Equals(object?)"/>
+        [Pure]
+        public override bool Equals(object? obj) =>
+            obj is Fingerprint other && Equals(other);
+
+        /// <inheritdoc cref="object.GetHashCode()"/>
+        [Pure]
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = (int)Type;
+                hashCode = (hashCode * 397) ^ EncodingLength;
+                hashCode = (hashCode * 397) ^ _hash.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        /// <summary>
+        /// Gets the hash digest of the value.
+        /// </summary>
+        /// <returns>The hash digest of the value.  It can be either empty or 20 bytes.</returns>
+        [Pure]
+        public byte[] GetHashArray() => _hash is { } h
+            ? new byte[20]
+                {
+                    h.Item1, h.Item2, h.Item3, h.Item4, h.Item5,
+                    h.Item6, h.Item7, h.Item8, h.Item9, h.Item10,
+                    h.Item11, h.Item12, h.Item13, h.Item14, h.Item15,
+                    h.Item16, h.Item17, h.Item18, h.Item19, h.Item20,
+                }
+            : Array.Empty<byte>();
+
+        /// <summary>
+        /// Serializes the fingerprint into bytes.
+        /// </summary>
+        /// <returns>The serialized bytes.  For the equivalent fingerprint, the equivalent bytes
+        /// is returned.</returns>
+        [Pure]
+        public byte[] Serialize()
+        {
+            byte[] hash = GetHashArray();
+            byte[] encLength = BitConverter.GetBytes(EncodingLength);
+            if (BitConverter.IsLittleEndian)
+            {
+                Array.Reverse(encLength);
+            }
+
+            var total = new byte[1 + hash.Length + encLength.Length];
+            total[0] = (byte)Type;
+            hash.CopyTo(total, 1);
+            encLength.CopyTo(total, 1 + hash.Length);
+            return total;
+        }
+
+        /// <inheritdoc cref="ISerializable.GetObjectData(SerializationInfo, StreamingContext)"/>
+        public void GetObjectData(SerializationInfo info, StreamingContext context)
+        {
+            info.AddValue(nameof(Type), (byte)Type);
+            info.AddValue(nameof(EncodingLength), EncodingLength);
+            info.AddValue(nameof(Hash), GetHashArray());
+        }
+    }
+}

--- a/Bencodex/Types/IValue.cs
+++ b/Bencodex/Types/IValue.cs
@@ -19,7 +19,15 @@ namespace Bencodex.Types
         /// <summary>
         /// The Bencodex type identifier.
         /// </summary>
+        [Pure]
         ValueType Type { get; }
+
+        /// <summary>
+        /// A unique identifier of the value.  Can be used for efficient determining of two values
+        /// that may be a deep tree.
+        /// </summary>
+        [Pure]
+        Fingerprint Fingerprint { get; }
 
         /// <summary>The number of bytes used for serializing the value.</summary>
         [Pure]

--- a/Bencodex/Types/IValue.cs
+++ b/Bencodex/Types/IValue.cs
@@ -16,6 +16,11 @@ namespace Bencodex.Types
     /// <seealso cref="Dictionary"/>
     public interface IValue : IEquatable<IValue>
     {
+        /// <summary>
+        /// The Bencodex type identifier.
+        /// </summary>
+        ValueType Type { get; }
+
         /// <summary>The number of bytes used for serializing the value.</summary>
         [Pure]
         int EncodingLength { get; }

--- a/Bencodex/Types/IValue.cs
+++ b/Bencodex/Types/IValue.cs
@@ -31,7 +31,7 @@ namespace Bencodex.Types
 
         /// <summary>The number of bytes used for serializing the value.</summary>
         [Pure]
-        int EncodingLength { get; }
+        long EncodingLength { get; }
 
         /// <summary>A JSON-like human-readable representation for
         /// debugging.</summary>

--- a/Bencodex/Types/Integer.cs
+++ b/Bencodex/Types/Integer.cs
@@ -82,8 +82,8 @@ namespace Bencodex.Types
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
-        public int EncodingLength =>
-            2 + Value.ToString(CultureInfo.InvariantCulture).Length;
+        public long EncodingLength =>
+            2L + Value.ToString(CultureInfo.InvariantCulture).Length;
 
         /// <inheritdoc cref="IValue.Inspection"/>
         [Pure]

--- a/Bencodex/Types/Integer.cs
+++ b/Bencodex/Types/Integer.cs
@@ -60,6 +60,10 @@ namespace Bencodex.Types
 
         public BigInteger Value { get; }
 
+        /// <inheritdoc cref="IValue.Type"/>
+        [Pure]
+        public ValueType Type => ValueType.Integer;
+
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
         public int EncodingLength =>

--- a/Bencodex/Types/Integer.cs
+++ b/Bencodex/Types/Integer.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.IO;
 using System.Numerics;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace Bencodex.Types
@@ -63,6 +64,21 @@ namespace Bencodex.Types
         /// <inheritdoc cref="IValue.Type"/>
         [Pure]
         public ValueType Type => ValueType.Integer;
+
+        /// <inheritdoc cref="IValue.Fingerprint"/>
+        [Pure]
+        public Fingerprint Fingerprint
+        {
+            get
+            {
+                // If the byte representation is compact enough, use it as a digest too.
+                // If it's longer than 20 bytes, make a SHA-1 hash for digest.
+                byte[] bytes = Value.ToByteArray();
+                IReadOnlyList<byte> digest =
+                    bytes.Length <= 20 ? bytes : SHA1.Create().ComputeHash(bytes);
+                return new Fingerprint(Type, EncodingLength, digest);
+            }
+        }
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -30,6 +30,10 @@ namespace Bencodex.Types
         public ImmutableArray<IValue> Value =>
             _value.IsDefault ? (_value = ImmutableArray<IValue>.Empty) : _value;
 
+        /// <inheritdoc cref="IValue.Type"/>
+        [Pure]
+        public ValueType Type => ValueType.List;
+
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
         public int EncodingLength =>

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -24,12 +24,12 @@ namespace Bencodex.Types
         /// The singleton fingerprint for empty lists.
         /// </summary>
         public static readonly Fingerprint EmptyFingerprint =
-            new Fingerprint(ValueType.List, 2);
+            new Fingerprint(ValueType.List, 2L);
 
         private static readonly byte[] _listPrefix = new byte[1] { 0x6c };  // 'l'
 
         private ImmutableArray<IValue> _value;
-        private int? _encodingLength;
+        private long? _encodingLength;
         private ImmutableArray<byte>? _hash;
 
         public List(IEnumerable<IValue> value)
@@ -59,7 +59,7 @@ namespace Bencodex.Types
 
                 if (!(_hash is { } hash))
                 {
-                    int encLength = 2;
+                    long encLength = 2;
                     SHA1 sha1 = SHA1.Create();
                     sha1.Initialize();
                     foreach (IValue value in els)
@@ -85,11 +85,11 @@ namespace Bencodex.Types
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
-        public int EncodingLength =>
+        public long EncodingLength =>
             _encodingLength is { } l ? l : (
-                _encodingLength = _listPrefix.Length
+                _encodingLength = _listPrefix.LongLength
                     + Value.Sum(e => e.EncodingLength)
-                    + CommonVariables.Suffix.Length
+                    + CommonVariables.Suffix.LongLength
             ).Value;
 
         /// <inheritdoc cref="IValue.Inspection"/>

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Security.Cryptography;
 
 namespace Bencodex.Types
 {
@@ -14,18 +15,29 @@ namespace Bencodex.Types
         IImmutableList<IValue>,
         IEquatable<IImmutableList<IValue>>
     {
+        /// <summary>
+        /// The empty list.
+        /// </summary>
+        public static readonly List Empty = default;
+
+        /// <summary>
+        /// The singleton fingerprint for empty lists.
+        /// </summary>
+        public static readonly Fingerprint EmptyFingerprint =
+            new Fingerprint(ValueType.List, 2);
+
         private static readonly byte[] _listPrefix = new byte[1] { 0x6c };  // 'l'
 
         private ImmutableArray<IValue> _value;
         private int? _encodingLength;
+        private ImmutableArray<byte>? _hash;
 
         public List(IEnumerable<IValue> value)
         {
             _value = value?.ToImmutableArray() ?? ImmutableArray<IValue>.Empty;
             _encodingLength = null;
+            _hash = null;
         }
-
-        public static List Empty => default(List);
 
         public ImmutableArray<IValue> Value =>
             _value.IsDefault ? (_value = ImmutableArray<IValue>.Empty) : _value;
@@ -33,6 +45,43 @@ namespace Bencodex.Types
         /// <inheritdoc cref="IValue.Type"/>
         [Pure]
         public ValueType Type => ValueType.List;
+
+        /// <inheritdoc cref="IValue.Fingerprint"/>
+        [Pure]
+        public Fingerprint Fingerprint
+        {
+            get
+            {
+                if (!(_value is { } els) || els.IsDefaultOrEmpty)
+                {
+                    return EmptyFingerprint;
+                }
+
+                if (!(_hash is { } hash))
+                {
+                    int encLength = 2;
+                    SHA1 sha1 = SHA1.Create();
+                    sha1.Initialize();
+                    foreach (IValue value in els)
+                    {
+                        Fingerprint fp = value.Fingerprint;
+                        byte[] fpb = fp.Serialize();
+                        sha1.TransformBlock(fpb, 0, fpb.Length, null, 0);
+                        encLength += fp.EncodingLength;
+                    }
+
+                    sha1.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                    hash = ImmutableArray.Create(sha1.Hash);
+                    _hash = hash;
+                    if (_encodingLength is null)
+                    {
+                        _encodingLength = encLength;
+                    }
+                }
+
+                return new Fingerprint(Type, EncodingLength, hash);
+            }
+        }
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]

--- a/Bencodex/Types/Null.cs
+++ b/Bencodex/Types/Null.cs
@@ -25,7 +25,7 @@ namespace Bencodex.Types
         /// The singleton fingerprint for the <see cref="Null"/> value.
         /// </summary>
         public static readonly Fingerprint SingletonFingerprint =
-            new Fingerprint(ValueType.Null, 1);
+            new Fingerprint(ValueType.Null, 1L);
 
         /// <inheritdoc cref="IValue.Type"/>
         [Pure]
@@ -37,7 +37,7 @@ namespace Bencodex.Types
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
-        public int EncodingLength => 1;
+        public long EncodingLength => 1L;
 
         /// <inheritdoc cref="IValue.Inspection"/>
         [Pure]

--- a/Bencodex/Types/Null.cs
+++ b/Bencodex/Types/Null.cs
@@ -21,6 +21,10 @@ namespace Bencodex.Types
             new Null();
 #pragma warning restore SA1129
 
+        /// <inheritdoc cref="IValue.Type"/>
+        [Pure]
+        public ValueType Type => ValueType.Null;
+
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
         public int EncodingLength => 1;

--- a/Bencodex/Types/Null.cs
+++ b/Bencodex/Types/Null.cs
@@ -21,9 +21,19 @@ namespace Bencodex.Types
             new Null();
 #pragma warning restore SA1129
 
+        /// <summary>
+        /// The singleton fingerprint for the <see cref="Null"/> value.
+        /// </summary>
+        public static readonly Fingerprint SingletonFingerprint =
+            new Fingerprint(ValueType.Null, 1);
+
         /// <inheritdoc cref="IValue.Type"/>
         [Pure]
         public ValueType Type => ValueType.Null;
+
+        /// <inheritdoc cref="IValue.Fingerprint"/>
+        [Pure]
+        public Fingerprint Fingerprint => SingletonFingerprint;
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]

--- a/Bencodex/Types/Text.cs
+++ b/Bencodex/Types/Text.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.IO;
+using System.Security.Cryptography;
 using System.Text;
 
 namespace Bencodex.Types
@@ -20,12 +22,14 @@ namespace Bencodex.Types
         private static readonly byte[] _keyPrefixByteArray = new byte[1] { _keyPrefix };
 
         private int? _utf8Length;
+        private ImmutableArray<byte>? _digest;
         private string? _value;
 
         public Text(string value)
         {
             _value = value ?? throw new ArgumentNullException(nameof(value));
             _utf8Length = null;
+            _digest = null;
         }
 
         public string Value => _value ?? (_value = string.Empty);
@@ -36,6 +40,30 @@ namespace Bencodex.Types
         /// <inheritdoc cref="IValue.Type"/>
         [Pure]
         public ValueType Type => ValueType.Text;
+
+        /// <inheritdoc cref="IValue.Fingerprint"/>
+        [Pure]
+        public Fingerprint Fingerprint
+        {
+            get
+            {
+                if (!(_digest is { } digest))
+                {
+                    byte[] utf8 = Encoding.UTF8.GetBytes(Value);
+                    if (utf8.Length > 20)
+                    {
+                        digest = ImmutableArray.Create(SHA1.Create().ComputeHash(utf8));
+                        _digest = digest;
+                    }
+                    else
+                    {
+                        digest = ImmutableArray.Create(utf8);
+                    }
+                }
+
+                return new Fingerprint(Type, EncodingLength, digest);
+            }
+        }
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]

--- a/Bencodex/Types/Text.cs
+++ b/Bencodex/Types/Text.cs
@@ -33,6 +33,10 @@ namespace Bencodex.Types
         [Pure]
         byte? IKey.KeyPrefix => _keyPrefix;  // 'u'
 
+        /// <inheritdoc cref="IValue.Type"/>
+        [Pure]
+        public ValueType Type => ValueType.Text;
+
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
         public int EncodingLength =>

--- a/Bencodex/Types/Text.cs
+++ b/Bencodex/Types/Text.cs
@@ -59,6 +59,11 @@ namespace Bencodex.Types
                     {
                         digest = ImmutableArray.Create(utf8);
                     }
+
+                    if (_utf8Length is null)
+                    {
+                        _utf8Length = utf8.Length;
+                    }
                 }
 
                 return new Fingerprint(Type, EncodingLength, digest);
@@ -67,10 +72,10 @@ namespace Bencodex.Types
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
-        public int EncodingLength =>
-            1 +
+        public long EncodingLength =>
+            1L +
             Utf8Length.ToString(CultureInfo.InvariantCulture).Length +
-            CommonVariables.Separator.Length +
+            CommonVariables.Separator.LongLength +
             Utf8Length;
 
         /// <inheritdoc cref="IValue.Inspection"/>

--- a/Bencodex/Types/ValueType.cs
+++ b/Bencodex/Types/ValueType.cs
@@ -1,0 +1,43 @@
+﻿namespace Bencodex.Types
+{
+    /// <summary>
+    /// The value to identify types of Bencodex values.
+    /// </summary>
+    public enum ValueType : byte
+    {
+        /// <summary>
+        /// Null (<c>n</c>).
+        /// </summary>
+        Null = 0,
+
+        /// <summary>
+        /// True (<c>t</c>) or false (<c>f</c>).
+        /// </summary>
+        Boolean = 1,
+
+        /// <summary>
+        /// Integers (<c>i...e</c>).
+        /// </summary>
+        Integer = 2,
+
+        /// <summary>
+        /// Byte strings (<c>N:...</c>).
+        /// </summary>
+        Binary = 3,
+
+        /// <summary>
+        /// Unicode strings (<c>uN:...</c>).
+        /// </summary>
+        Text = 4,
+
+        /// <summary>
+        /// Lists (<c>l...e</c>).
+        /// </summary>
+        List = 5,
+
+        /// <summary>
+        /// Dictionaries (<c>d...e</c>).
+        /// </summary>
+        Dictionary = 6,
+    }
+}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Version 0.4.0
 To be released.
 
  -  Added `Bencodex.Types.ValueType` enum type.
+ -  Added `Bencodex.Types.Fingerprint` readonly struct.
  -  Added `IValue.Type` property.
  -  Added `IValue.EncodingLength` property.
  -  Removed `Bencodex.Types.CommonVariables` static class.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,8 +10,18 @@ To be released.
  -  Added `Bencodex.Types.Fingerprint` readonly struct.
  -  Added `Bencodex.Misc.FingerprintComparer` class.
  -  Added `IValue.Type` property.
+ -  Added `IValue.Fingerprint` property.
  -  Added `IValue.EncodingLength` property.
+ -  Added `Null.SingletonFingerprint` static readonly field.
+ -  Added `Boolean.TrueFingerprint` static readonly field.
+ -  Added `Boolean.FalseFingerprint` static readonly field.
+ -  Added `List.EmptyFingerprint` static readonly field.
+ -  Added `Dictionary.EmptyFingerprint` static readonly field.
  -  Added `Bencodex.Misc.ImmutableByteArrayExtensions` static class.
+ -  Replaced `Binary(byte[])` constructor with `Binary(params byte[])`
+    constructor.
+ -  `List.Empty` static property became a static readonly field.
+ -  `Dictionary.Empty` static property became a static readonly field.
  -  Removed `Bencodex.Types.CommonVariables` static class.
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ To be released.
  -  Added `Bencodex.Types.Fingerprint` readonly struct.
  -  Added `IValue.Type` property.
  -  Added `IValue.EncodingLength` property.
+ -  Added `Bencodex.Misc.ImmutableByteArrayExtensions` static class.
  -  Removed `Bencodex.Types.CommonVariables` static class.
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ Version 0.4.0
 
 To be released.
 
+ -  Added `Bencodex.Types.ValueType` enum type.
+ -  Added `IValue.Type` property.
  -  Added `IValue.EncodingLength` property.
  -  Removed `Bencodex.Types.CommonVariables` static class.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,23 +6,26 @@ Version 0.4.0
 
 To be released.
 
- -  Added `Bencodex.Types.ValueType` enum type.
- -  Added `Bencodex.Types.Fingerprint` readonly struct.
- -  Added `Bencodex.Misc.FingerprintComparer` class.
- -  Added `IValue.Type` property.
- -  Added `IValue.Fingerprint` property.
- -  Added `IValue.EncodingLength` property.
- -  Added `Null.SingletonFingerprint` static readonly field.
- -  Added `Boolean.TrueFingerprint` static readonly field.
- -  Added `Boolean.FalseFingerprint` static readonly field.
- -  Added `List.EmptyFingerprint` static readonly field.
- -  Added `Dictionary.EmptyFingerprint` static readonly field.
- -  Added `Bencodex.Misc.ImmutableByteArrayExtensions` static class.
+ -  Added `Bencodex.Types.ValueType` enum type.  [[#50]]
+ -  Added `Bencodex.Types.Fingerprint` readonly struct.  [[#50]]
+ -  Added `Bencodex.Misc.FingerprintComparer` class.  [[#50]]
+ -  Added `IValue.Type` property.  [[#50]]
+ -  Added `IValue.Fingerprint` property.  [[#50]]
+ -  Added `IValue.EncodingLength` property.  [[#49], [#50]]
+ -  Added `Null.SingletonFingerprint` static readonly field.  [[#50]]
+ -  Added `Boolean.TrueFingerprint` static readonly field.  [[#50]]
+ -  Added `Boolean.FalseFingerprint` static readonly field.  [[#50]]
+ -  Added `List.EmptyFingerprint` static readonly field.  [[#50]]
+ -  Added `Dictionary.EmptyFingerprint` static readonly field.  [[#50]]
+ -  Added `Bencodex.Misc.ImmutableByteArrayExtensions` static class.  [[#50]]
  -  Replaced `Binary(byte[])` constructor with `Binary(params byte[])`
-    constructor.
- -  `List.Empty` static property became a static readonly field.
- -  `Dictionary.Empty` static property became a static readonly field.
- -  Removed `Bencodex.Types.CommonVariables` static class.
+    constructor.  [[#50]]
+ -  `List.Empty` static property became a static readonly field.  [[#50]]
+ -  `Dictionary.Empty` static property became a static readonly field.  [[#50]]
+ -  Removed `Bencodex.Types.CommonVariables` static class.  [[#50]]
+
+[#49]: https://github.com/planetarium/bencodex.net/pull/49
+[#50]: https://github.com/planetarium/bencodex.net/pull/50
 
 
 Version 0.3.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ To be released.
 
  -  Added `Bencodex.Types.ValueType` enum type.
  -  Added `Bencodex.Types.Fingerprint` readonly struct.
+ -  Added `Bencodex.Misc.FingerprintComparer` class.
  -  Added `IValue.Type` property.
  -  Added `IValue.EncodingLength` property.
  -  Added `Bencodex.Misc.ImmutableByteArrayExtensions` static class.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 Bencodex codec for .NET
 =======================
 
-[![Build Status][]][build]
+[![GitHub Actions Status][]][GitHub Actions]
+[![NuGet](https://img.shields.io/nuget/v/Bencodex)][NuGet]
 
 This library implements [Bencodex] serialization format which extends
 [Bencoding].
 
+[GitHub Actions]: https://github.com/planetarium/bencodex.net/actions
+[GitHub Actions Status]: https://github.com/planetarium/bencodex.net/workflows/build/badge.svg?event=push
+[NuGet]: https://www.nuget.org/packages/Bencodex
 [Bencodex]: https://github.com/planetarium/bencodex
 [Bencoding]: http://www.bittorrent.org/beps/bep_0003.html#bencoding
-[build]: https://github.com/planetarium/bencodex.net/actions
-[Build Status]: https://github.com/planetarium/bencodex.net/workflows/build/badge.svg?event=push
 
 
 Usage


### PR DESCRIPTION
Added `IValue.Fingerprint` for efficient tree comparison.