### PR TITLE
Optimize `List` & `Dictionary` types

### DIFF
--- a/Bencodex.Benchmarks/ValueBenchmark.cs
+++ b/Bencodex.Benchmarks/ValueBenchmark.cs
@@ -1,0 +1,104 @@
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Bencodex.Types;
+
+namespace Bencodex.Benchmarks
+{
+    public class ValueBenchmark
+    {
+        private static readonly Binary _binFoo = new Binary("foo", Encoding.ASCII);
+        private static readonly Text _txtFoo = (Text)"foo";
+        private static readonly List _list = List.Empty
+            .Add("foo")
+            .Add("bar")
+            .Add(true)
+            .Add(Null.Value)
+            .Add(1234)
+            .Add(Dictionary.Empty.Add("foo", 123).Add("bar", 456))
+            .Add(List.Empty.Add("a").Add("b").Add("c"));
+        private static readonly List _listCopyA = _list.Add(1);
+        private static readonly List _listCopyB = _list.Add(1);
+        private static readonly Dictionary _dict = Dictionary.Empty
+            .Add("foo", "bar")
+            .Add("baz", "qux")
+            .Add("bool", true)
+            .Add("null", Null.Value)
+            .Add("int", 1234)
+            .Add("dict", Dictionary.Empty.Add("foo", 123).Add("bar", 456))
+            .Add("list", new IValue[] { (Text)"a", (Text)"b", (Text)"c" });
+        private static readonly Dictionary _dictCopyA = _dict.Add("z", 1);
+        private static readonly Dictionary _dictCopyB = _dict.Add("z", 1);
+
+        [Benchmark]
+        public void List_AddBinFromEmpty()
+        {
+            IValue _ = List.Empty.Add((IValue)_binFoo);
+        }
+
+        [Benchmark]
+        public void List_AddTxtFromEmpty()
+        {
+            IValue _ = List.Empty.Add((IValue)_txtFoo);
+        }
+
+        [Benchmark]
+        public void List_Add()
+        {
+            IValue _ = _list.Add(_dict);
+        }
+
+        [Benchmark]
+        public void List_Equal()
+        {
+            bool _ = _listCopyA.Equals(_listCopyB);
+        }
+
+        [Benchmark]
+        public void List_NotEqual()
+        {
+            bool _ = _listCopyA.Equals(_list);
+        }
+
+        [Benchmark]
+        public void Dict_AddBinKeyFromEmpty()
+        {
+            IValue _ = (Dictionary)Dictionary.Empty.Add((IKey)_binFoo, _txtFoo);
+        }
+
+        [Benchmark]
+        public void Dict_AddTxtKeyFromEmpty()
+        {
+            IValue _ = (Dictionary)Dictionary.Empty.Add((IKey)_txtFoo, _binFoo);
+        }
+
+        [Benchmark]
+        public void Dict_AddKey()
+        {
+            IValue _ = (Dictionary)_dict.Add((IKey)_binFoo, _list);
+        }
+
+        [Benchmark]
+        public void Dict_LookUpExist()
+        {
+            _dict.TryGetValue(_txtFoo, out IValue _);
+        }
+
+        [Benchmark]
+        public void Dict_LookUpNonExist()
+        {
+            _dict.TryGetValue(_binFoo, out IValue _);
+        }
+
+        [Benchmark]
+        public void Dict_Equal()
+        {
+            bool _ = _dictCopyA.Equals(_dictCopyB);
+        }
+
+        [Benchmark]
+        public void Dict_NotEqual()
+        {
+            bool _ = _dictCopyA.Equals(_dict);
+        }
+    }
+}

--- a/Bencodex.Tests/Misc/KeyComparerTest.cs
+++ b/Bencodex.Tests/Misc/KeyComparerTest.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+using System.Text;
+using Bencodex.Misc;
+using Bencodex.Types;
+using Xunit;
+
+namespace Bencodex.Tests.Misc
+{
+    public class KeyComparerTest
+    {
+        [Fact]
+        public void Compare()
+        {
+            var unordered = new List<IKey>
+            {
+                new Binary("foo", Encoding.ASCII),
+                new Binary("bar", Encoding.ASCII),
+                (Text)"foo",
+                (Text)"bar",
+                (Text)"a",
+                (Text)"\u00e1",
+                (Text)"a\u0301",
+            };
+            IKey[] ordered =
+            {
+                new Binary("bar", Encoding.ASCII),
+                new Binary("foo", Encoding.ASCII),
+                (Text)"a",
+                (Text)"a\u0301",
+                (Text)"bar",
+                (Text)"foo",
+                (Text)"\u00e1",
+            };
+
+            unordered.Sort(KeyComparer.Instance);
+            Assert.Equal(ordered, unordered);
+            Assert.Equal(
+                new HashSet<IKey>(unordered),
+                new SortedSet<IKey>(unordered, KeyComparer.Instance)
+            );
+        }
+    }
+}

--- a/Bencodex.Tests/TestUtils.cs
+++ b/Bencodex.Tests/TestUtils.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Bencodex.Tests
+{
+    public static class TestUtils
+    {
+        public static void AssertEqual(
+            byte[] expected,
+            byte[] actual,
+            string message = null
+        )
+        {
+            Encoding utf8 = Encoding.GetEncoding(
+                "UTF-8",
+                new EncoderReplacementFallback(),
+                new DecoderReplacementFallback()
+            );
+            Assert.True(
+                expected.SequenceEqual(actual),
+                string.Format(
+                    "{4}{5}" +
+                    "Expected: {0}\nActual:   {1}\n" +
+                    "Expected (hex): {2}\nActual (hex):   {3}",
+                    utf8.GetString(expected),
+                    utf8.GetString(actual),
+                    BitConverter.ToString(expected),
+                    BitConverter.ToString(actual),
+                    message ?? string.Empty,
+                    message == null ? string.Empty : "\n"
+                )
+            );
+        }
+    }
+}

--- a/Bencodex.Tests/Types/FingerprintTest.cs
+++ b/Bencodex.Tests/Types/FingerprintTest.cs
@@ -60,24 +60,32 @@ namespace Bencodex.Tests.Types
             Assert.True(l123A.Equals((object)l123A_));
             Assert.Equal(l123A.GetHashCode(), l123A_.GetHashCode());
             Assert.Equal(l123A.Serialize(), l123A_.Serialize());
+            Assert.True(l123A == l123A_);
+            Assert.False(l123A != l123A_);
 
             var d123A = new Fingerprint(ValueType.Dictionary, 123, hashA);
             Assert.NotEqual(l123A, d123A);
             Assert.False(l123A.Equals((object)d123A));
             Assert.NotEqual(l123A.GetHashCode(), d123A.GetHashCode());
             Assert.NotEqual(l123A.Serialize(), d123A.Serialize());
+            Assert.False(l123A == d123A);
+            Assert.True(l123A != d123A);
 
             var l122A = new Fingerprint(ValueType.List, 122, hashA);
             Assert.NotEqual(l123A, l122A);
             Assert.False(l123A.Equals((object)l122A));
             Assert.NotEqual(l123A.GetHashCode(), l122A.GetHashCode());
             Assert.NotEqual(l123A.Serialize(), l122A.Serialize());
+            Assert.False(l123A == l122A);
+            Assert.True(l123A != l122A);
 
             var l123B = new Fingerprint(ValueType.List, 123, hashB);
             Assert.NotEqual(l123A, l123B);
             Assert.False(l123A.Equals((object)l123B));
             Assert.NotEqual(l123A.GetHashCode(), l123B.GetHashCode());
             Assert.NotEqual(l123A.Serialize(), l123B.Serialize());
+            Assert.False(l123A == l123B);
+            Assert.True(l123A != l123B);
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/ValueTests.cs
+++ b/Bencodex.Tests/Types/ValueTests.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Bencodex.Types;
 using Xunit;
 using Xunit.Abstractions;
+using static Bencodex.Tests.TestUtils;
 using ValueType = Bencodex.Types.ValueType;
 
 namespace Bencodex.Tests.Types
@@ -157,37 +158,6 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
-        public void List()
-        {
-            // FIXME: Move to ListTest.
-            var zero = default(List);
-            var two = new List(new Text[] { "hello", "world" }.Cast<IValue>());
-
-            AssertEqual(
-                new byte[] { 0x6c, 0x65 },  // "le"
-                _codec.Encode(zero)
-            );
-            AssertEqual(
-                new byte[] { 0x6c, 0x65 },  // "le"
-                _codec.Encode(new List(new IValue[0]))
-            );
-            AssertEqual(
-                new byte[] { 0x6c, 0x65 },  // "le"
-                _codec.Encode(new List(ImmutableList<IValue>.Empty))
-            );
-            AssertEqual(
-                new byte[]
-                {
-                    0x6c, 0x75, 0x35, 0x3a, 0x68, 0x65, 0x6c, 0x6c, 0x6f,
-                    0x75, 0x35, 0x3a, 0x77, 0x6f, 0x72, 0x6c, 0x64, 0x65,
-
-                    // "lu5:hellou5:worlde"
-                },
-                _codec.Encode(two)
-            );
-        }
-
-        [Fact]
         public void Dictionary()
         {
             // FIXME: Move to DictionaryTest.
@@ -274,33 +244,6 @@ namespace Bencodex.Tests.Types
                     _codec.Encode(i)
                 );
             }
-        }
-
-        private void AssertEqual(
-            byte[] expected,
-            byte[] actual,
-            string message = null
-        )
-        {
-            Encoding utf8 = Encoding.GetEncoding(
-                "UTF-8",
-                new EncoderReplacementFallback(),
-                new DecoderReplacementFallback()
-            );
-            Assert.True(
-                expected.SequenceEqual(actual),
-                string.Format(
-                    "{4}{5}" +
-                    "Expected: {0}\nActual:   {1}\n" +
-                    "Expected (hex): {2}\nActual (hex):   {3}",
-                    utf8.GetString(expected),
-                    utf8.GetString(actual),
-                    BitConverter.ToString(expected),
-                    BitConverter.ToString(actual),
-                    message ?? string.Empty,
-                    message == null ? string.Empty : "\n"
-                )
-            );
         }
     }
 }

--- a/Bencodex.Tests/Types/ValueTests.cs
+++ b/Bencodex.Tests/Types/ValueTests.cs
@@ -157,48 +157,6 @@ namespace Bencodex.Tests.Types
             Assert.Equal("Bencodex.Types.Text \"\u4f60\u597d\"", nihao.ToString());
         }
 
-        [Fact]
-        public void Dictionary()
-        {
-            // FIXME: Move to DictionaryTest.
-            AssertEqual(
-                new byte[] { 0x64, 0x65 },  // "de"
-                _codec.Encode(
-                    new Dictionary(ImmutableDictionary<IKey, IValue>.Empty)
-                )
-            );
-            AssertEqual(
-                new byte[] { 0x64, 0x65 },  // "de"
-                _codec.Encode(
-                    new Dictionary(new KeyValuePair<IKey, IValue>[0])
-                )
-            );
-            AssertEqual(
-                new byte[]
-                {
-                    0x64, 0x31, 0x3a, 0x63, 0x69, 0x31, 0x65,
-                    0x75, 0x31, 0x3a, 0x61, 0x69, 0x32, 0x65,
-                    0x75, 0x31, 0x3a, 0x62, 0x69, 0x33, 0x65, 0x65,
-
-                    // "d1:ci1eu1:ai2eu1:bi3ee"
-                },
-                _codec.Encode(
-                    new Dictionary(
-                        new Dictionary<IKey, IValue>()
-                        {
-                            { (Text)"a", (Integer)2 },
-                            { (Text)"b", (Integer)3 },
-                            {
-                                // "c" => 3
-                                (Binary)new byte[] { 0x63 },
-                                (Integer)1
-                            },
-                        }
-                    )
-                )
-            );
-        }
-
         [Theory]
         [ClassData(typeof(SpecTheoryData))]
         public void SpecTestSuite(Spec spec)

--- a/Bencodex/Misc/KeyComparer.cs
+++ b/Bencodex/Misc/KeyComparer.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Bencodex.Types;
+using ValueType = Bencodex.Types.ValueType;
+
+namespace Bencodex.Misc
+{
+    /// <summary>
+    /// Compares two <see cref="IKey"/> values.  The order is according to the Bencodex
+    /// specification on dictionary keys.
+    /// </summary>
+    public sealed class KeyComparer : IComparer<IKey>
+    {
+        /// <summary>
+        /// The singleton instance of <see cref="KeyComparer"/>.
+        /// </summary>
+        public static readonly KeyComparer Instance = new KeyComparer();
+
+        private static readonly ByteArrayComparer _binaryComparer = default;
+
+        private KeyComparer()
+        {
+        }
+
+        /// <inheritdoc cref="IComparer{T}.Compare(T, T)"/>
+        public int Compare(IKey x, IKey y)
+        {
+            if (x is Binary xb && y is Binary yb)
+            {
+                return _binaryComparer.Compare(xb.ByteArray, yb.ByteArray);
+            }
+            else if (x is Text xt && y is Text yt)
+            {
+                return string.CompareOrdinal(xt.Value, yt.Value);
+            }
+
+            return (x.Type == ValueType.Text).CompareTo(y.Type == ValueType.Text);
+        }
+    }
+}

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -15,8 +15,10 @@ namespace Bencodex.Types
     /// <summary>
     /// Represents Bencodex dictionaries.
     /// </summary>
+    [Pure]
     public class Dictionary :
         IValue,
+        IEquatable<Dictionary>,
         IEquatable<IImmutableDictionary<IKey, IValue>>,
         IImmutableDictionary<IKey, IValue>
     {
@@ -36,14 +38,7 @@ namespace Bencodex.Types
 
         private static readonly byte[] _unicodeKeyPrefix = new byte[1] { 0x75 };  // 'u'
 
-        private static IComparer<ValueTuple<byte?, byte[]>> keyPairComparer =
-            new CompositeComparer<byte?, byte[]>(
-                Comparer<byte?>.Default,
-                default(ByteArrayComparer)
-            );
-
-        private ImmutableDictionary<IKey, IValue>? _dict;
-        private KeyValuePair<IKey, IValue>[]? _pairs;
+        private ImmutableSortedDictionary<IKey, IValue> _dict;
         private ImmutableArray<byte>? _hash;
         private long _encodingLength = -1;
 
@@ -53,60 +48,39 @@ namespace Bencodex.Types
         /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
         /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<IKey, IValue>> pairs)
+            : this(pairs.ToImmutableSortedDictionary(KeyComparer.Instance))
         {
-            _pairs = pairs.ToArray();
         }
 
         /// <summary>
         /// Creates a <see cref="Dictionary"/> instance with the <paramref name="content"/>.
         /// </summary>
         /// <param name="content">The dictionary content.</param>
-        public Dictionary(in ImmutableDictionary<IKey, IValue> content)
+        public Dictionary(in ImmutableSortedDictionary<IKey, IValue> content)
         {
-            _dict = content;
+            _dict = content.KeyComparer == KeyComparer.Instance
+                ? content
+                : content.WithComparers(KeyComparer.Instance);
         }
 
-        public int Count => Value.Count;
+        /// <inheritdoc cref="IReadOnlyCollection{T}.Count"/>
+        public int Count => _dict.Count;
 
-        public IEnumerable<IKey> Keys =>
-            Value.Keys;
+        /// <inheritdoc cref="IReadOnlyDictionary{TKey,TValue}.Keys"/>
+        public IEnumerable<IKey> Keys => _dict.Keys;
 
-        public IEnumerable<IValue> Values =>
-            Value.Values;
+        /// <inheritdoc cref="IReadOnlyDictionary{TKey,TValue}.Values"/>
+        public IEnumerable<IValue> Values => _dict.Values;
 
         /// <inheritdoc cref="IValue.Type"/>
-        [Pure]
         public ValueType Type => ValueType.Dictionary;
 
         /// <inheritdoc cref="IValue.Fingerprint"/>
-        [Pure]
         public Fingerprint Fingerprint
         {
             get
             {
-                if (_dict is { } d && d.IsEmpty)
-                {
-                    return EmptyFingerprint;
-                }
-                else if (_pairs is { } p && p.Length < 1)
-                {
-                    return EmptyFingerprint;
-                }
-
-                var pairs = _dict ?? _pairs ?? Enumerable.Empty<KeyValuePair<IKey, IValue>>();
-                var fDict = new SortedDictionary<Fingerprint, Fingerprint>(
-                    new FingerprintComparer()
-                );
-                foreach (KeyValuePair<IKey, IValue> kv in pairs)
-                {
-                    Fingerprint keyF = kv.Key.Fingerprint;
-                    if (!fDict.ContainsKey(keyF))
-                    {
-                        fDict[keyF] = kv.Value.Fingerprint;
-                    }
-                }
-
-                if (!fDict.Any())
+                if (_dict.Count < 1)
                 {
                     return EmptyFingerprint;
                 }
@@ -116,11 +90,11 @@ namespace Bencodex.Types
                     long encLength = 2L;
                     SHA1 sha1 = SHA1.Create();
                     sha1.Initialize();
-                    foreach (KeyValuePair<Fingerprint, Fingerprint> pair in fDict)
+                    foreach (KeyValuePair<IKey, IValue> pair in this)
                     {
-                        byte[] fp = pair.Key.Serialize();
+                        byte[] fp = pair.Key.Fingerprint.Serialize();
                         sha1.TransformBlock(fp, 0, fp.Length, null, 0);
-                        fp = pair.Value.Serialize();
+                        fp = pair.Value.Fingerprint.Serialize();
                         sha1.TransformBlock(fp, 0, fp.Length, null, 0);
                         encLength += pair.Key.EncodingLength +
                                      pair.Value.EncodingLength;
@@ -140,25 +114,19 @@ namespace Bencodex.Types
         }
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
-        [Pure]
         public long EncodingLength =>
             _encodingLength >= 0
                 ? _encodingLength
                 : _encodingLength = _dictionaryPrefix.LongLength
-                    + Value.Sum(kv => kv.Key.EncodingLength + kv.Value.EncodingLength)
+                    + _dict.Sum(kv => kv.Key.EncodingLength + kv.Value.EncodingLength)
                     + CommonVariables.Suffix.LongLength;
 
         /// <inheritdoc cref="IValue.Inspection"/>
-        [Pure]
         public string Inspection
         {
             get
             {
-                if (_dict is { } d && d.IsEmpty)
-                {
-                    return "{}";
-                }
-                else if (_pairs is { } p && p.Length < 1)
+                if (_dict.Count < 1)
                 {
                     return "{}";
                 }
@@ -171,25 +139,8 @@ namespace Bencodex.Types
             }
         }
 
-        [Pure]
-        private ImmutableDictionary<IKey, IValue> Value
-        {
-            get
-            {
-                if (!(_dict is { } dict))
-                {
-                    dict = _pairs.ToImmutableDictionary();
-                    _dict = dict;
-                    _pairs = null;
-                }
-
-                return dict;
-            }
-        }
-
         /// <inheritdoc cref="IReadOnlyDictionary{TKey,TValue}.this[TKey]"/>
-        [Pure]
-        public IValue this[IKey key] => Value[key];
+        public IValue this[IKey key] => _dict[key];
 
         public IValue this[string key] => this[(IKey)new Text(key)];
 
@@ -197,15 +148,14 @@ namespace Bencodex.Types
 
         public IValue this[byte[] key] => this[(IKey)new Binary(key)];
 
-        public IEnumerator<KeyValuePair<IKey, IValue>> GetEnumerator() => Value?.GetEnumerator()
-            ?? Enumerable.Empty<KeyValuePair<IKey, IValue>>().GetEnumerator();
+        /// <inheritdoc cref="IEnumerable{T}.GetEnumerator()"/>
+        public IEnumerator<KeyValuePair<IKey, IValue>> GetEnumerator() => _dict.GetEnumerator();
 
-        IEnumerator IEnumerable.GetEnumerator() =>
-            (IEnumerator<KeyValuePair<IKey, IValue>>)GetEnumerator();
+        /// <inheritdoc cref="IEnumerable.GetEnumerator()"/>
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <inheritdoc cref="IReadOnlyDictionary{TKey,TValue}.ContainsKey(TKey)"/>
-        [Pure]
-        public bool ContainsKey(IKey key) => Value.ContainsKey(key);
+        public bool ContainsKey(IKey key) => _dict.ContainsKey(key);
 
         public bool ContainsKey(string key) => ContainsKey((IKey)new Text(key));
 
@@ -214,12 +164,12 @@ namespace Bencodex.Types
         public bool ContainsKey(byte[] key) => ContainsKey((IKey)new Binary(key));
 
         /// <inheritdoc cref="IReadOnlyDictionary{TKey,TValue}.TryGetValue(TKey, out TValue)"/>
-        [Pure]
         public bool TryGetValue(IKey key, out IValue value) =>
-            Value.TryGetValue(key, out value);
+            _dict.TryGetValue(key, out value);
 
+        /// <inheritdoc cref="IImmutableDictionary{TKey,TValue}.Add(TKey, TValue)"/>
         public IImmutableDictionary<IKey, IValue> Add(IKey key, IValue value) =>
-            new Dictionary(Value.Add(key, value));
+            new Dictionary(_dict.Add(key, value));
 
         public Dictionary Add(string key, IValue value) =>
             (Dictionary)Add((IKey)new Text(key), value);
@@ -277,32 +227,30 @@ namespace Bencodex.Types
         public Dictionary Add(byte[] key, IEnumerable<IValue> value) =>
             Add(key, (IValue)new List(value));
 
+        /// <inheritdoc cref="IImmutableDictionary{TKey,TValue}.AddRange"/>
         public IImmutableDictionary<IKey, IValue> AddRange(
             IEnumerable<KeyValuePair<IKey, IValue>> pairs
         ) =>
-            new Dictionary(Value.AddRange(pairs));
+            new Dictionary(_dict.AddRange(pairs));
 
         /// <inheritdoc cref="IImmutableDictionary{TKey,TValue}.Clear()"/>
-        [Pure]
         public IImmutableDictionary<IKey, IValue> Clear() => Empty;
 
         /// <inheritdoc
         /// cref="IImmutableDictionary{TKey,TValue}.Contains(KeyValuePair{TKey, TValue})"/>
-        [Pure]
-        public bool Contains(KeyValuePair<IKey, IValue> pair) => Value.Contains(pair);
+        public bool Contains(KeyValuePair<IKey, IValue> pair) => _dict.Contains(pair);
 
         /// <inheritdoc cref="IImmutableDictionary{TKey,TValue}.Remove(TKey)"/>
-        [Pure]
         public IImmutableDictionary<IKey, IValue> Remove(IKey key) =>
-            Value.IsEmpty ? this : new Dictionary(Value.Remove(key));
+            _dict.Count < 1 ? this : new Dictionary(_dict.Remove(key));
 
         /// <inheritdoc cref="IImmutableDictionary{TKey,TValue}.RemoveRange(IEnumerable{TKey})"/>
-        [Pure]
         public IImmutableDictionary<IKey, IValue> RemoveRange(IEnumerable<IKey> keys) =>
-            Value.IsEmpty ? this : new Dictionary(Value.RemoveRange(keys));
+            _dict.Count < 1 ? this : new Dictionary(_dict.RemoveRange(keys));
 
+        /// <inheritdoc cref="IImmutableDictionary{TKey,TValue}.SetItem(TKey,TValue)"/>
         public IImmutableDictionary<IKey, IValue> SetItem(IKey key, IValue value) =>
-            new Dictionary(Value.SetItem(key, value));
+            new Dictionary(_dict.SetItem(key, value));
 
         public Dictionary SetItem(IKey key, string value) =>
             (Dictionary)SetItem(key, (IValue)new Text(value));
@@ -397,15 +345,15 @@ namespace Bencodex.Types
         public Dictionary SetItem(byte[] key, IEnumerable<IValue> value) =>
             SetItem(key, (IValue)new List(value));
 
+        /// <inheritdoc cref="IImmutableDictionary{TKey,TValue}.SetItems"/>
         public IImmutableDictionary<IKey, IValue> SetItems(
             IEnumerable<KeyValuePair<IKey, IValue>> items
         ) =>
-            new Dictionary(Value.SetItems(items));
+            new Dictionary(_dict.SetItems(items));
 
         /// <inheritdoc cref="IImmutableDictionary{TKey,TValue}.TryGetKey(TKey, out TKey)"/>
-        [Pure]
         public bool TryGetKey(IKey equalKey, out IKey actualKey) =>
-            Value.TryGetKey(equalKey, out actualKey);
+            _dict.TryGetKey(equalKey, out actualKey);
 
         public T GetValue<T>(string name)
             where T : IValue
@@ -433,12 +381,26 @@ namespace Bencodex.Types
             };
 
         /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
-        [Pure]
+        public bool Equals(Dictionary other)
+        {
+            if (Count != other.Count)
+            {
+                return false;
+            }
+            else if (_hash is { } && other._hash is { })
+            {
+                return Fingerprint.Equals(other.Fingerprint);
+            }
+
+            return ((IEquatable<IImmutableDictionary<IKey, IValue>>)this).Equals(other);
+        }
+
+        /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
         bool IEquatable<IImmutableDictionary<IKey, IValue>>.Equals(
             IImmutableDictionary<IKey, IValue> other
         )
         {
-            if (Value.LongCount() != other.LongCount())
+            if (_dict.Count != other.Count)
             {
                 return false;
             }
@@ -456,54 +418,29 @@ namespace Bencodex.Types
         }
 
         /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
-        [Pure]
         bool IEquatable<IValue>.Equals(IValue other) =>
             other is Dictionary o &&
             ((IEquatable<IImmutableDictionary<IKey, IValue>>)this).Equals(o);
 
         /// <inheritdoc cref="object.GetHashCode()"/>
-        [Pure]
-        public override int GetHashCode() => Value.GetHashCode();
+        public override int GetHashCode() => _dict.GetHashCode();
 
         /// <inheritdoc cref="IValue.EncodeIntoChunks()"/>
-        [Pure]
         public IEnumerable<byte[]> EncodeIntoChunks()
         {
             // FIXME: avoid duplication between this and EncodeToStream()
             long length = _dictionaryPrefix.LongLength;
             yield return _dictionaryPrefix;
 
-            var @enum = _dict ?? _pairs ?? Enumerable.Empty<KeyValuePair<IKey, IValue>>();
-            IEnumerable<ValueTuple<byte?, byte[], IValue>> rawPairs =
-                from pair in @enum
-                select (
-                    pair.Key.KeyPrefix,
-                    pair.Key.EncodeAsByteArray(),
-                    pair.Value
-                );
-            IEnumerable<ValueTuple<byte?, byte[], IValue>> orderedPairs = rawPairs.OrderBy(
-                triple => (triple.Item1, triple.Item2),
-                keyPairComparer
-            );
-            var byteArrayComparer = default(ByteArrayComparer);
-            (byte? keyPrefix, byte[] key)? prev = null;
-            foreach ((byte? keyPrefix, byte[] key, IValue value) in orderedPairs)
+            foreach (KeyValuePair<IKey, IValue> pair in this)
             {
-                // Skip duplicates
-                if (_dict is null && prev is { } p)
-                {
-                    if (p.keyPrefix == keyPrefix && byteArrayComparer.Compare(p.key, key) == 0)
-                    {
-                        continue;
-                    }
-                }
-
-                if (keyPrefix != null)
+                if (pair.Key.Type == ValueType.Text)
                 {
                     yield return _unicodeKeyPrefix;
                     length += _unicodeKeyPrefix.LongLength;
                 }
 
+                byte[] key = pair.Key.EncodeAsByteArray();
                 byte[] keyLengthBytes = Encoding.ASCII.GetBytes(
                     key.Length.ToString(CultureInfo.InvariantCulture)
                 );
@@ -513,13 +450,11 @@ namespace Bencodex.Types
                 length += CommonVariables.Separator.LongLength;
                 yield return key;
                 length += key.LongLength;
-                foreach (byte[] chunk in value.EncodeIntoChunks())
+                foreach (byte[] chunk in pair.Value.EncodeIntoChunks())
                 {
                     yield return chunk;
                     length += chunk.LongLength;
                 }
-
-                prev = (keyPrefix, key);
             }
 
             yield return CommonVariables.Suffix;
@@ -528,58 +463,33 @@ namespace Bencodex.Types
         }
 
         /// <inheritdoc cref="IValue.EncodeToStream(Stream)"/>
-        [Pure]
         public void EncodeToStream(Stream stream)
         {
             // FIXME: avoid duplication between this and EncodeIntoChunks()
             long startPos = stream.Position;
             stream.WriteByte(_dictionaryPrefix[0]);
 
-            var @enum = _dict ?? _pairs ?? Enumerable.Empty<KeyValuePair<IKey, IValue>>();
-            IEnumerable<ValueTuple<byte?, byte[], IValue>> rawPairs =
-                from pair in @enum
-                select (
-                    pair.Key.KeyPrefix,
-                    pair.Key.EncodeAsByteArray(),
-                    pair.Value
-                );
-            IEnumerable<ValueTuple<byte?, byte[], IValue>> orderedPairs = rawPairs.OrderBy(
-                triple => (triple.Item1, triple.Item2),
-                keyPairComparer
-            );
-            var byteArrayComparer = default(ByteArrayComparer);
-            (byte? keyPrefix, byte[] key)? prev = null;
-            foreach ((byte? keyPrefix, byte[] key, IValue value) in orderedPairs)
+            foreach (KeyValuePair<IKey, IValue> pair in this)
             {
-                // Skip duplicates
-                if (_dict is null && prev is { } p)
-                {
-                    if (p.keyPrefix == keyPrefix && byteArrayComparer.Compare(p.key, key) == 0)
-                    {
-                        continue;
-                    }
-                }
-
-                if (keyPrefix != null)
+                if (pair.Key.Type == ValueType.Text)
                 {
                     stream.WriteByte(_unicodeKeyPrefix[0]);
                 }
 
+                byte[] key = pair.Key.EncodeAsByteArray();
                 var keyLen =
                     key.Length.ToString(CultureInfo.InvariantCulture);
                 var keyLenBytes = Encoding.ASCII.GetBytes(keyLen);
                 stream.Write(keyLenBytes, 0, keyLenBytes.Length);
                 stream.WriteByte(CommonVariables.Separator[0]);
                 stream.Write(key, 0, key.Length);
-                value.EncodeToStream(stream);
-                prev = (keyPrefix, key);
+                pair.Value.EncodeToStream(stream);
             }
 
             stream.WriteByte(CommonVariables.Suffix[0]);
             _encodingLength = stream.Position - startPos;
         }
 
-        [Pure]
         public override string ToString() =>
             $"{nameof(Bencodex)}.{nameof(Bencodex.Types)}.{nameof(Dictionary)} {Inspection}";
     }

--- a/Bencodex/Types/Fingerprint.cs
+++ b/Bencodex/Types/Fingerprint.cs
@@ -93,6 +93,26 @@ namespace Bencodex.Types
         public ImmutableArray<byte> Digest { get; }
 
         /// <summary>
+        /// Tests if two <see cref="Fingerprint"/> values are equal.
+        /// </summary>
+        /// <param name="a">A <see cref="Fingerprint"/> value to compare.</param>
+        /// <param name="b">Another <see cref="Fingerprint"/> value to compare.</param>
+        /// <returns><c>true</c> if two values are equal.  Otherwise <c>false</c>.</returns>
+        [Pure]
+        public static bool operator ==(in Fingerprint a, in Fingerprint b) =>
+            a.Equals(b);
+
+        /// <summary>
+        /// Tests if two <see cref="Fingerprint"/> values are not equal.
+        /// </summary>
+        /// <param name="a">A <see cref="Fingerprint"/> value to compare.</param>
+        /// <param name="b">Another <see cref="Fingerprint"/> value to compare.</param>
+        /// <returns><c>false</c> if two values are equal.  Otherwise <c>true</c>.</returns>
+        [Pure]
+        public static bool operator !=(Fingerprint a, Fingerprint b) =>
+            !a.Equals(b);
+
+        /// <summary>
         /// Deserialized the serialized fingerprint bytes.
         /// </summary>
         /// <param name="serialized">The bytes made by <see cref="Serialize()"/> method.</param>

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -32,9 +32,31 @@ namespace Bencodex.Types
         private long? _encodingLength;
         private ImmutableArray<byte>? _hash;
 
-        public List(IEnumerable<IValue> value)
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
+        public List(params IValue[] elements)
+            : this(ImmutableArray.Create(elements))
         {
-            _value = value?.ToImmutableArray() ?? ImmutableArray<IValue>.Empty;
+        }
+
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
+        public List(IEnumerable<IValue> elements)
+            : this(elements.ToImmutableArray())
+        {
+        }
+
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
+        public List(in ImmutableArray<IValue> elements)
+        {
+            _value = elements;
             _encodingLength = null;
             _hash = null;
         }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,16 +7,17 @@ Version 0.4.0
 To be released.
 
  -  Added `Bencodex.Types.ValueType` enum type.  [[#50]]
- -  Added `Bencodex.Types.Fingerprint` readonly struct.  [[#50]]
- -  Added `Bencodex.Misc.FingerprintComparer` class.  [[#50]]
+ -  Bencodex values now have their unqiue fingerprints:  [[#50]]
+     -  Added `Bencodex.Types.Fingerprint` readonly struct.
+     -  Added `Bencodex.Misc.FingerprintComparer` class.
+     -  Added `IValue.Fingerprint` property.
+     -  Added `Null.SingletonFingerprint` static readonly field.
+     -  Added `Boolean.TrueFingerprint` static readonly field.
+     -  Added `Boolean.FalseFingerprint` static readonly field.
+     -  Added `List.EmptyFingerprint` static readonly field.
+     -  Added `Dictionary.EmptyFingerprint` static readonly field.
  -  Added `IValue.Type` property.  [[#50]]
- -  Added `IValue.Fingerprint` property.  [[#50]]
  -  Added `IValue.EncodingLength` property.  [[#49], [#50]]
- -  Added `Null.SingletonFingerprint` static readonly field.  [[#50]]
- -  Added `Boolean.TrueFingerprint` static readonly field.  [[#50]]
- -  Added `Boolean.FalseFingerprint` static readonly field.  [[#50]]
- -  Added `List.EmptyFingerprint` static readonly field.  [[#50]]
- -  Added `Dictionary.EmptyFingerprint` static readonly field.  [[#50]]
  -  Added `Bencodex.Misc.ImmutableByteArrayExtensions` static class.  [[#50]]
  -  Replaced `Binary(byte[])` constructor with `Binary(params byte[])`
     constructor.  [[#50]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ Version 0.4.0
 
 To be released.
 
+ -  `Bencodex.Types.List` struct became a class.  [[#51]]
  -  Added `Bencodex.Types.ValueType` enum type.  [[#50]]
  -  Bencodex values now have their unqiue fingerprints:  [[#50]]
      -  Added `Bencodex.Types.Fingerprint` readonly struct.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ Version 0.4.0
 To be released.
 
  -  `Bencodex.Types.List` struct became a class.  [[#51]]
+ -  `Bencodex.Types.Dictionary` readonly struct became a class.  [[#51]]
  -  Added `Bencodex.Types.ValueType` enum type.  [[#50]]
  -  Bencodex values now have their unqiue fingerprints:  [[#50]]
      -  Added `Bencodex.Types.Fingerprint` readonly struct.
@@ -24,6 +25,8 @@ To be released.
     constructor.  [[#50]]
  -  Added `List(in ImmutableArray<IValue>)` constructor.  [[#51]]
  -  Added `List(params IValue[])` constructor.  [[#51]]
+ -  Added `Dictionary(in ImmutableDictionary<IKey, IValue>)` constructor.
+     [[#51]]
  -  `List.Empty` static property became a static readonly field.  [[#50]]
  -  `Dictionary.Empty` static property became a static readonly field.  [[#50]]
  -  Removed `Bencodex.Types.CommonVariables` static class.  [[#50]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,8 @@ To be released.
  -  Added `Bencodex.Misc.ImmutableByteArrayExtensions` static class.  [[#50]]
  -  Replaced `Binary(byte[])` constructor with `Binary(params byte[])`
     constructor.  [[#50]]
+ -  Added `List(in ImmutableArray<IValue>)` constructor.  [[#51]]
+ -  Added `List(params IValue[])` constructor.  [[#51]]
  -  `List.Empty` static property became a static readonly field.  [[#50]]
  -  `Dictionary.Empty` static property became a static readonly field.  [[#50]]
  -  Removed `Bencodex.Types.CommonVariables` static class.  [[#50]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ To be released.
  -  Added `List(params IValue[])` constructor.  [[#51]]
  -  Added `Dictionary(in ImmutableDictionary<IKey, IValue>)` constructor.
      [[#51]]
+ -  Added `Bencodex.Misc.KeyComparer` class.  [[#51]]
  -  `List.Empty` static property became a static readonly field.  [[#50]]
  -  `Dictionary.Empty` static property became a static readonly field.  [[#50]]
  -  Removed `Bencodex.Types.CommonVariables` static class.  [[#50]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ To be released.
 
  -  `Bencodex.Types.List` struct became a class.  [[#51]]
  -  `Bencodex.Types.Dictionary` readonly struct became a class.  [[#51]]
+ -  `Bencodex.Types.Dictionary` now implements
+    `IEquatable<Bencodex.Types.Dictionary>` interface.  [[#51]]
  -  Added `Bencodex.Types.ValueType` enum type.  [[#50]]
  -  Bencodex values now have their unqiue fingerprints:  [[#50]]
      -  Added `Bencodex.Types.Fingerprint` readonly struct.
@@ -25,7 +27,7 @@ To be released.
     constructor.  [[#50]]
  -  Added `List(in ImmutableArray<IValue>)` constructor.  [[#51]]
  -  Added `List(params IValue[])` constructor.  [[#51]]
- -  Added `Dictionary(in ImmutableDictionary<IKey, IValue>)` constructor.
+ -  Added `Dictionary(in ImmutableSortedDictionary<IKey, IValue>)` constructor.
      [[#51]]
  -  Added `Bencodex.Misc.KeyComparer` class.  [[#51]]
  -  `List.Empty` static property became a static readonly field.  [[#50]]


### PR DESCRIPTION
This patch optimizes `List` and `Dictionary` types by refactoring them.

- Both types are now reference types.
- Every `Dictionary` instance is always sorted as [`ImmutableSortedDictionary<K, V>`][1] is used as its internal data structure.
    - Due to this, I can get rid of its dual internal representations (`Dict` mode & `Pairs` mode) which were quite complicated.

### Benchmarks before this patch

|           Method |             DataFile |      Mean |    Error |    StdDev |
|----------------- |--------------------- |----------:|---------:|----------:|
|  EncodeIntoBytes | /tmp/(...)e.dat [96] | 27.853 ms | 3.870 ms | 0.2121 ms |
| EncodeIntoStream | /tmp/(...)e.dat [96] | 21.257 ms | 4.667 ms | 0.2558 ms |
|  DecodeFromBytes | /tmp/(...)e.dat [96] |  8.122 ms | 8.924 ms | 0.4891 ms |
| DecodeFromStream | /tmp/(...)e.dat [96] |  8.216 ms | 5.635 ms | 0.3089 ms |

|                  Method |         Mean |      Error |    StdDev |
|------------------------ |-------------:|-----------:|----------:|
|    List_AddBinFromEmpty |    44.08 ns |     1.898 ns |  0.104 ns |
|    List_AddTxtFromEmpty |    42.67 ns |     2.461 ns |  0.135 ns |
|                List_Add |    61.24 ns |     7.991 ns |  0.438 ns |
|              List_Equal | 2,536.95 ns | 1,124.775 ns | 61.653 ns |
|           List_NotEqual | 2,416.80 ns |   273.405 ns | 14.986 ns |
| Dict_AddBinKeyFromEmpty |   665.40 ns |   189.475 ns | 10.386 ns |
| Dict_AddTxtKeyFromEmpty |   662.04 ns |    21.364 ns |  1.171 ns |
|             Dict_AddKey | 1,987.12 ns |    36.047 ns |  1.976 ns |
|        Dict_LookUpExist |    47.29 ns |    19.495 ns |  1.069 ns |
|     Dict_LookUpNonExist |    32.03 ns |     1.824 ns |  0.100 ns |
|              Dict_Equal | 7,375.63 ns | 1,504.051 ns | 82.442 ns |
|           Dict_NotEqual | 2,595.29 ns |    61.605 ns |  3.377 ns |

### Benchmarks after this patch

|           Method |             DataFile |      Mean |    Error |    StdDev |
|----------------- |--------------------- |----------:|---------:|----------:|
|  EncodeIntoBytes | /tmp/(...)e.dat [96] | 27.946 ms | 6.385 ms | 0.3500 ms |
| EncodeIntoStream | /tmp/(...)e.dat [96] | 21.738 ms | 3.136 ms | 0.1719 ms |
|  DecodeFromBytes | /tmp/(...)e.dat [96] |  8.232 ms | 4.241 ms | 0.2325 ms |
| DecodeFromStream | /tmp/(...)e.dat [96] |  8.601 ms | 7.952 ms | 0.4359 ms |

|                  Method |         Mean |      Error |    StdDev |
|------------------------ |-------------:|-----------:|----------:|
|    List_AddBinFromEmpty |    40.849 ns |  2.2660 ns | 0.1242 ns |
|    List_AddTxtFromEmpty |    40.057 ns |  0.6456 ns | 0.0354 ns |
|                List_Add |    50.728 ns |  8.4574 ns | 0.4636 ns |
|              List_Equal | 1,068.539 ns | 63.0099 ns | 3.4538 ns |
|           List_NotEqual | 1,027.934 ns | 60.0094 ns | 3.2893 ns |
| Dict_AddBinKeyFromEmpty |    73.809 ns |  1.4620 ns | 0.0801 ns |
| Dict_AddTxtKeyFromEmpty |    73.608 ns | 10.8463 ns | 0.5945 ns |
|             Dict_AddKey |   235.382 ns |  1.7675 ns | 0.0969 ns |
|        Dict_LookUpExist |    34.646 ns |  0.9301 ns | 0.0510 ns |
|     Dict_LookUpNonExist |    80.287 ns | 12.4760 ns | 0.6839 ns |
|              Dict_Equal | 2,369.966 ns | 92.6779 ns | 5.0800 ns |
|           Dict_NotEqual |     9.185 ns |  0.1734 ns | 0.0095 ns |

[1]: https://docs.microsoft.com/en-us/dotnet/api/system.collections.immutable.immutablesorteddictionary-2?view=netcore-3.1