### PR TITLE
Let `List`/`Dictionary` expose their `IndirectValue`s

### DIFF
--- a/Bencodex.Tests/Misc/FingerprintComparerTest.cs
+++ b/Bencodex.Tests/Misc/FingerprintComparerTest.cs
@@ -5,7 +5,6 @@ using Bencodex.Types;
 using Xunit;
 using static Bencodex.Misc.ImmutableByteArrayExtensions;
 using F = Bencodex.Types.Fingerprint;
-using T = Bencodex.Types.ValueType;
 
 namespace Bencodex.Tests.Misc
 {
@@ -14,24 +13,24 @@ namespace Bencodex.Tests.Misc
         [Fact]
         public void Compare()
         {
-            var n = new F(T.Null, 1);
-            var f = new F(T.Boolean, 1, new byte[] { 0 });
-            var t = new F(T.Boolean, 1, new byte[] { 1 });
-            var i0 = new F(T.Integer, 3, new byte[] { 0 });
-            var i45 = new F(T.Integer, 4, new byte[] { 45 });
-            var iM123 = new F(T.Integer, 6, new byte[] { 0b10000101 });
-            var b = new F(T.Binary, 2);
-            var bHello = new F(T.Binary, 7, Encoding.ASCII.GetBytes("hello"));
-            var b445 = new F(T.Binary, 449, ParseHex("cd36b370758a259b34845084a6cc38473cb95e27"));
-            var u = new F(T.Text, 3);
-            var uNihao = new F(T.Text, 9, new byte[] { 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd });
-            var u42 = new F(T.Text, 46, ParseHex("e72dcfd0ae50a80aaa8c1a78b27e2e11bef66488"));
-            var l = new F(T.List, 2);
-            var l1 = new F(T.List, 3, ParseHex("ae7fca60943c2ef2f6cf5420477da41acf29b01d"));
-            var l2 = new F(T.List, 18, ParseHex("22852139f287a01cdb803fd86ed70e4c4d121254"));
-            var lNest = new F(T.List, 26, ParseHex("24caa983a5225522ca798be3b31a1abecdb36fe5"));
-            var d = new F(T.Dictionary, 2);
-            var d1 = new F(T.Dictionary, 14, ParseHex("9312bb9fe32ec11b4e6478f557ea821b0c44523d"));
+            var n = new F(ValueKind.Null, 1);
+            var f = new F(ValueKind.Boolean, 1, new byte[] { 0 });
+            var t = new F(ValueKind.Boolean, 1, new byte[] { 1 });
+            var i0 = new F(ValueKind.Integer, 3, new byte[] { 0 });
+            var i45 = new F(ValueKind.Integer, 4, new byte[] { 45 });
+            var iM123 = new F(ValueKind.Integer, 6, new byte[] { 0b10000101 });
+            var b = new F(ValueKind.Binary, 2);
+            var bHello = new F(ValueKind.Binary, 7, Encoding.ASCII.GetBytes("hello"));
+            var b445 = new F(ValueKind.Binary, 449, ParseHex("cd36b370758a259b34845084a6cc38473cb95e27"));
+            var u = new F(ValueKind.Text, 3);
+            var uNihao = new F(ValueKind.Text, 9, new byte[] { 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd });
+            var u42 = new F(ValueKind.Text, 46, ParseHex("e72dcfd0ae50a80aaa8c1a78b27e2e11bef66488"));
+            var l = new F(ValueKind.List, 2);
+            var l1 = new F(ValueKind.List, 3, ParseHex("ae7fca60943c2ef2f6cf5420477da41acf29b01d"));
+            var l2 = new F(ValueKind.List, 18, ParseHex("22852139f287a01cdb803fd86ed70e4c4d121254"));
+            var lNest = new F(ValueKind.List, 26, ParseHex("24caa983a5225522ca798be3b31a1abecdb36fe5"));
+            var d = new F(ValueKind.Dictionary, 2);
+            var d1 = new F(ValueKind.Dictionary, 14, ParseHex("9312bb9fe32ec11b4e6478f557ea821b0c44523d"));
             var unordered = new List<Fingerprint>
             {
                 lNest, l2, u, n, bHello, i0, l1, uNihao,

--- a/Bencodex.Tests/Types/BinaryTest.cs
+++ b/Bencodex.Tests/Types/BinaryTest.cs
@@ -58,18 +58,18 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
-        public void Type()
+        public void Kind()
         {
-            Assert.Equal(ValueType.Binary, _empty.Type);
-            Assert.Equal(ValueType.Binary, _hello.Type);
+            Assert.Equal(ValueKind.Binary, _empty.Kind);
+            Assert.Equal(ValueKind.Binary, _hello.Kind);
         }
 
         [Fact]
         public void Fingerprint()
         {
-            Assert.Equal(new Fingerprint(ValueType.Binary, 2L), _empty.Fingerprint);
+            Assert.Equal(new Fingerprint(ValueKind.Binary, 2L), _empty.Fingerprint);
             Assert.Equal(
-                new Fingerprint(ValueType.Binary, 7L, _hello.ByteArray),
+                new Fingerprint(ValueKind.Binary, 7L, _hello.ByteArray),
                 _hello.Fingerprint
             );
 
@@ -84,7 +84,7 @@ namespace Bencodex.Tests.Types
             );
             Assert.Equal(
                 new Fingerprint(
-                    ValueType.Binary,
+                    ValueKind.Binary,
                     449L,
                     ParseHex("cd36b370758a259b34845084a6cc38473cb95e27")
                 ),

--- a/Bencodex.Tests/Types/BooleanTest.cs
+++ b/Bencodex.Tests/Types/BooleanTest.cs
@@ -13,21 +13,21 @@ namespace Bencodex.Tests.Types
         public void SingletonFingerprints()
         {
             Assert.Equal(
-                new Fingerprint(ValueType.Boolean, 1L, new byte[] { 1 }),
+                new Fingerprint(ValueKind.Boolean, 1L, new byte[] { 1 }),
                 Boolean.TrueFingerprint
             );
             Assert.Equal(
-                new Fingerprint(ValueType.Boolean, 1L, new byte[] { 0 }),
+                new Fingerprint(ValueKind.Boolean, 1L, new byte[] { 0 }),
                 Boolean.FalseFingerprint
             );
             Assert.NotEqual(Boolean.FalseFingerprint, Boolean.TrueFingerprint);
         }
 
         [Fact]
-        public void Type()
+        public void Kind()
         {
-            Assert.Equal(ValueType.Boolean, _t.Type);
-            Assert.Equal(ValueType.Boolean, _f.Type);
+            Assert.Equal(ValueKind.Boolean, _t.Kind);
+            Assert.Equal(ValueKind.Boolean, _f.Kind);
         }
 
         [Fact]
@@ -40,8 +40,8 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void Fingerprint()
         {
-            Assert.Equal(new Fingerprint(ValueType.Boolean, 1L, new byte[] { 1 }), _t.Fingerprint);
-            Assert.Equal(new Fingerprint(ValueType.Boolean, 1L, new byte[] { 0 }), _f.Fingerprint);
+            Assert.Equal(new Fingerprint(ValueKind.Boolean, 1L, new byte[] { 1 }), _t.Fingerprint);
+            Assert.Equal(new Fingerprint(ValueKind.Boolean, 1L, new byte[] { 0 }), _f.Fingerprint);
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -7,6 +7,9 @@ using Bencodex.Types;
 using Xunit;
 using static Bencodex.Misc.ImmutableByteArrayExtensions;
 using static Bencodex.Tests.TestUtils;
+using IEquatableDict = System.IEquatable<System.Collections.Immutable.IImmutableDictionary<
+    Bencodex.Types.IKey,
+    Bencodex.Types.IValue>>;
 using ValueType = Bencodex.Types.ValueType;
 
 namespace Bencodex.Tests.Types
@@ -153,6 +156,25 @@ namespace Bencodex.Tests.Types
 
             Assert.True(_partiallyLoaded.Equals(_loaded));
             Assert.False(_partiallyLoaded.Equals(_loaded.Add("zzz", 1)));
+            Assert.False(_partiallyLoaded.Equals(_loaded.SetItem("b", "update")));
+            Assert.Empty(_loadLog);
+
+            Assert.True(((IEquatableDict)_partiallyLoaded).Equals(_loaded));
+            Assert.False(((IEquatableDict)_partiallyLoaded).Equals(_loaded.Add("zzz", 1)));
+            Assert.False(((IEquatableDict)_partiallyLoaded).Equals(_loaded.SetItem("b", "update")));
+            Assert.Empty(_loadLog);
+
+            Assert.True(((IEquatableDict)_partiallyLoaded).Equals(_loaded.ToImmutableDictionary()));
+            Assert.False(
+                ((IEquatableDict)_partiallyLoaded).Equals(
+                    _loaded.Add("zzz", 1).ToImmutableDictionary()
+                )
+            );
+            Assert.False(
+                ((IEquatableDict)_partiallyLoaded).Equals(
+                    _loaded.SetItem("b", "update").ToImmutableDictionary()
+                )
+            );
             Assert.Empty(_loadLog);
         }
 

--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -10,7 +10,6 @@ using static Bencodex.Tests.TestUtils;
 using IEquatableDict = System.IEquatable<System.Collections.Immutable.IImmutableDictionary<
     Bencodex.Types.IKey,
     Bencodex.Types.IValue>>;
-using ValueType = Bencodex.Types.ValueType;
 
 namespace Bencodex.Tests.Types
 {
@@ -450,24 +449,24 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
-        public void Type()
+        public void Kind()
         {
-            Assert.Equal(ValueType.Dictionary, Dictionary.Empty.Type);
-            Assert.Equal(ValueType.Dictionary, _textKey.Type);
-            Assert.Equal(ValueType.Dictionary, _binaryKey.Type);
-            Assert.Equal(ValueType.Dictionary, _partiallyLoaded.Type);
+            Assert.Equal(ValueKind.Dictionary, Dictionary.Empty.Kind);
+            Assert.Equal(ValueKind.Dictionary, _textKey.Kind);
+            Assert.Equal(ValueKind.Dictionary, _binaryKey.Kind);
+            Assert.Equal(ValueKind.Dictionary, _partiallyLoaded.Kind);
         }
 
         [Fact]
         public void Fingerprint()
         {
             Assert.Equal(
-                new Fingerprint(ValueType.Dictionary, 2),
+                new Fingerprint(ValueKind.Dictionary, 2),
                 Dictionary.Empty.Fingerprint
             );
             Assert.Equal(
                 new Fingerprint(
-                    ValueType.Dictionary,
+                    ValueKind.Dictionary,
                     14L,
                     ParseHex("bb1bbb4428e03722aa5e5ad2e0d70657e328dae1")
                 ),
@@ -475,7 +474,7 @@ namespace Bencodex.Tests.Types
             );
             Assert.Equal(
                 new Fingerprint(
-                    ValueType.Dictionary,
+                    ValueKind.Dictionary,
                     13L,
                     ParseHex("0a4571a67289be466635ecc577ac136452d8d532")
                 ),
@@ -483,7 +482,7 @@ namespace Bencodex.Tests.Types
             );
             Assert.Equal(
                 new Fingerprint(
-                    ValueType.Dictionary,
+                    ValueKind.Dictionary,
                     33,
                     ParseHex("83f7620e739e4dd9c6443a93eae4ff9132580ff3")
                 ),

--- a/Bencodex.Tests/Types/FingerprintTest.cs
+++ b/Bencodex.Tests/Types/FingerprintTest.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
 using Bencodex.Types;
 using Xunit;
-using ValueType = Bencodex.Types.ValueType;
 
 namespace Bencodex.Tests.Types
 {
@@ -13,14 +12,14 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void Constructor()
         {
-            var f = new Fingerprint(ValueType.Binary, 5, new byte[] { 1, 2, 3, 4, 5 });
-            Assert.Equal(ValueType.Binary, f.Type);
+            var f = new Fingerprint(ValueKind.Binary, 5, new byte[] { 1, 2, 3, 4, 5 });
+            Assert.Equal(ValueKind.Binary, f.Kind);
             Assert.Equal(5L, f.EncodingLength);
             Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, f.GetDigest());
 
             byte[] hash = new Random().NextBytes(20);
-            f = new Fingerprint(ValueType.List, 100, hash);
-            Assert.Equal(ValueType.List, f.Type);
+            f = new Fingerprint(ValueKind.List, 100, hash);
+            Assert.Equal(ValueKind.List, f.Kind);
             Assert.Equal(100L, f.EncodingLength);
             Assert.Equal(hash, f.GetDigest());
         }
@@ -28,16 +27,16 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void Digest()
         {
-            var nullId = new Fingerprint(ValueType.Null, 1);
+            var nullId = new Fingerprint(ValueKind.Null, 1);
             Assert.Empty(nullId.Digest);
             Assert.Empty(nullId.GetDigest());
 
-            var binId = new Fingerprint(ValueType.Binary, 5, new byte[] { 1, 2, 3, 4, 5 });
+            var binId = new Fingerprint(ValueKind.Binary, 5, new byte[] { 1, 2, 3, 4, 5 });
             Assert.Equal(new byte[] { 1, 2, 3, 4, 5 }, binId.GetDigest());
             Assert.Equal(binId.GetDigest(), binId.Digest);
 
             var hash = new Random().NextBytes(20);
-            var listId = new Fingerprint(ValueType.List, 123, hash);
+            var listId = new Fingerprint(ValueKind.List, 123, hash);
             Assert.Equal(hash, listId.Digest);
             Assert.Equal(hash, listId.GetDigest());
         }
@@ -51,11 +50,11 @@ namespace Bencodex.Tests.Types
             hashB[19] = (byte)(hashA[19] >= 0xff ? 0 : hashA[19] + 1);
             Assert.NotEqual(hashA, hashB);
 
-            var l123A = new Fingerprint(ValueType.List, 123, hashA);
+            var l123A = new Fingerprint(ValueKind.List, 123, hashA);
             Assert.False(l123A.Equals(null));
             Assert.False(l123A.Equals("other"));
 
-            var l123A_ = new Fingerprint(ValueType.List, 123, hashA.ToImmutableList());
+            var l123A_ = new Fingerprint(ValueKind.List, 123, hashA.ToImmutableList());
             Assert.Equal(l123A, l123A_);
             Assert.True(l123A.Equals((object)l123A_));
             Assert.Equal(l123A.GetHashCode(), l123A_.GetHashCode());
@@ -63,7 +62,7 @@ namespace Bencodex.Tests.Types
             Assert.True(l123A == l123A_);
             Assert.False(l123A != l123A_);
 
-            var d123A = new Fingerprint(ValueType.Dictionary, 123, hashA);
+            var d123A = new Fingerprint(ValueKind.Dictionary, 123, hashA);
             Assert.NotEqual(l123A, d123A);
             Assert.False(l123A.Equals((object)d123A));
             Assert.NotEqual(l123A.GetHashCode(), d123A.GetHashCode());
@@ -71,7 +70,7 @@ namespace Bencodex.Tests.Types
             Assert.False(l123A == d123A);
             Assert.True(l123A != d123A);
 
-            var l122A = new Fingerprint(ValueType.List, 122, hashA);
+            var l122A = new Fingerprint(ValueKind.List, 122, hashA);
             Assert.NotEqual(l123A, l122A);
             Assert.False(l123A.Equals((object)l122A));
             Assert.NotEqual(l123A.GetHashCode(), l122A.GetHashCode());
@@ -79,7 +78,7 @@ namespace Bencodex.Tests.Types
             Assert.False(l123A == l122A);
             Assert.True(l123A != l122A);
 
-            var l123B = new Fingerprint(ValueType.List, 123, hashB);
+            var l123B = new Fingerprint(ValueKind.List, 123, hashB);
             Assert.NotEqual(l123A, l123B);
             Assert.False(l123A.Equals((object)l123B));
             Assert.NotEqual(l123A.GetHashCode(), l123B.GetHashCode());
@@ -93,9 +92,9 @@ namespace Bencodex.Tests.Types
         {
             var random = new Random();
             byte[] hash = random.NextBytes(20);
-            var f = new Fingerprint(ValueType.List, 123, hash);
+            var f = new Fingerprint(ValueKind.List, 123, hash);
             Assert.Equal(
-                new Fingerprint(ValueType.List, 123, hash.ToImmutableList()).Serialize(),
+                new Fingerprint(ValueKind.List, 123, hash.ToImmutableList()).Serialize(),
                 f.Serialize()
             );
             Assert.Equal(f, Fingerprint.Deserialize(f.Serialize()));
@@ -107,7 +106,7 @@ namespace Bencodex.Tests.Types
             Assert.Equal(f, (Fingerprint)formatter.Deserialize(s));
 
             hash = random.NextBytes(20);
-            f = new Fingerprint(ValueType.Dictionary, 456, hash);
+            f = new Fingerprint(ValueKind.Dictionary, 456, hash);
             Assert.Equal(f, Fingerprint.Deserialize(f.Serialize()));
 
             s = new MemoryStream();
@@ -119,16 +118,16 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void String()
         {
-            var f = new Fingerprint(ValueType.Null, 1);
+            var f = new Fingerprint(ValueKind.Null, 1);
             Assert.Equal("Null [1 B]", f.ToString());
 
-            f = new Fingerprint(ValueType.Boolean, 1, new byte[] { 1 });
+            f = new Fingerprint(ValueKind.Boolean, 1, new byte[] { 1 });
             Assert.Equal("Boolean 01 [1 B]", f.ToString());
 
-            f = new Fingerprint(ValueType.Binary, 7, new byte[] { 0x12, 0xff, 0xab, 0x67, 0x99 });
+            f = new Fingerprint(ValueKind.Binary, 7, new byte[] { 0x12, 0xff, 0xab, 0x67, 0x99 });
             Assert.Equal("Binary 12ffab6799 [7 B]", f.ToString());
 
-            f = new Fingerprint(ValueType.List, 100, new byte[20]);
+            f = new Fingerprint(ValueKind.List, 100, new byte[20]);
             Assert.Equal("List 0000000000000000000000000000000000000000 [100 B]", f.ToString());
         }
     }

--- a/Bencodex.Tests/Types/IndirectValueTest.cs
+++ b/Bencodex.Tests/Types/IndirectValueTest.cs
@@ -2,7 +2,6 @@ using System;
 using System.Text;
 using Bencodex.Types;
 using Xunit;
-using ValueType = Bencodex.Types.ValueType;
 
 namespace Bencodex.Tests.Types
 {
@@ -72,10 +71,10 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
-        public void Type()
+        public void Kind()
         {
-            Assert.Equal(ValueType.List, _loaded.Type);
-            Assert.Equal(ValueType.Dictionary, _unloaded.Type);
+            Assert.Equal(ValueKind.List, _loaded.Type);
+            Assert.Equal(ValueKind.Dictionary, _unloaded.Type);
             Assert.Null(_unloaded.LoadedValue);
             Assert.Throws<InvalidOperationException>(() => _default.Type);
         }

--- a/Bencodex.Tests/Types/IntegerTest.cs
+++ b/Bencodex.Tests/Types/IntegerTest.cs
@@ -5,7 +5,6 @@ using Bencodex.Types;
 using Xunit;
 using static Bencodex.Misc.ImmutableByteArrayExtensions;
 using static Bencodex.Tests.TestUtils;
-using ValueType = Bencodex.Types.ValueType;
 
 namespace Bencodex.Tests.Types
 {
@@ -33,11 +32,11 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
-        public void Type()
+        public void Kind()
         {
-            Assert.Equal(ValueType.Integer, new Integer(0).Type);
-            Assert.Equal(ValueType.Integer, new Integer(123).Type);
-            Assert.Equal(ValueType.Integer, new Integer(-456).Type);
+            Assert.Equal(ValueKind.Integer, new Integer(0).Kind);
+            Assert.Equal(ValueKind.Integer, new Integer(123).Kind);
+            Assert.Equal(ValueKind.Integer, new Integer(-456).Kind);
         }
 
         [Fact]
@@ -52,15 +51,15 @@ namespace Bencodex.Tests.Types
         public void Fingerprint()
         {
             Assert.Equal(
-                new Fingerprint(ValueType.Integer, 3L, new byte[] { 0 }),
+                new Fingerprint(ValueKind.Integer, 3L, new byte[] { 0 }),
                 new Integer(0).Fingerprint
             );
             Assert.Equal(
-                new Fingerprint(ValueType.Integer, 4L, new byte[] { 45 }),
+                new Fingerprint(ValueKind.Integer, 4L, new byte[] { 45 }),
                 new Integer(45).Fingerprint
             );
             Assert.Equal(
-                new Fingerprint(ValueType.Integer, 6L, new byte[] { 0b10000101 }),
+                new Fingerprint(ValueKind.Integer, 6L, new byte[] { 0b10000101 }),
                 new Integer(-123).Fingerprint
             );
             BigInteger bigint = BigInteger.Parse(
@@ -69,7 +68,7 @@ namespace Bencodex.Tests.Types
             );
             Assert.Equal(
                 new Fingerprint(
-                    ValueType.Integer,
+                    ValueKind.Integer,
                     51L,
                     ParseHex("8209ad2f4fad401d8e3d33def02577bd9ab550e5")
                 ),

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -388,6 +388,29 @@ namespace Bencodex.Tests.Types
             );
         }
 
+        [Fact]
+        public void EnumerateIndirectValues()
+        {
+            Assert.Empty(_zero.EnumerateIndirectValues());
+            Assert.All(_one.EnumerateIndirectValues(), iv => Assert.NotNull(iv.LoadedValue));
+            Assert.Equal(_one.Select(v => new IndirectValue(v)), _one.EnumerateIndirectValues());
+            Assert.All(_two.EnumerateIndirectValues(), iv => Assert.NotNull(iv.LoadedValue));
+            Assert.Equal(_two.Select(v => new IndirectValue(v)), _two.EnumerateIndirectValues());
+            Assert.All(_nest.EnumerateIndirectValues(), iv => Assert.NotNull(iv.LoadedValue));
+            Assert.Equal(_nest.Select(v => new IndirectValue(v)), _nest.EnumerateIndirectValues());
+
+            Assert.Equal(_partiallyLoadedContents, _partiallyLoaded.EnumerateIndirectValues());
+            int i = 0;
+            foreach (IndirectValue iv in _partiallyLoaded.EnumerateIndirectValues())
+            {
+                Assert.Equal(_partiallyLoadedContents[i].Fingerprint, iv.Fingerprint);
+                Assert.Equal(_partiallyLoadedContents[i].LoadedValue, iv.LoadedValue);
+                i++;
+            }
+
+            Assert.Empty(_loadLog);
+        }
+
         private IValue Loader(Fingerprint f)
         {
             _loadLog.Add(f);

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -79,25 +79,25 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
-        public void Type()
+        public void Kind()
         {
-            Assert.Equal(ValueType.List, _zero.Type);
-            Assert.Equal(ValueType.List, _one.Type);
-            Assert.Equal(ValueType.List, _two.Type);
-            Assert.Equal(ValueType.List, _nest.Type);
-            Assert.Equal(ValueType.List, _partiallyLoaded.Type);
+            Assert.Equal(ValueKind.List, _zero.Kind);
+            Assert.Equal(ValueKind.List, _one.Kind);
+            Assert.Equal(ValueKind.List, _two.Kind);
+            Assert.Equal(ValueKind.List, _nest.Kind);
+            Assert.Equal(ValueKind.List, _partiallyLoaded.Kind);
         }
 
         [Fact]
         public void Fingerprint()
         {
             Assert.Equal(
-                new Fingerprint(ValueType.List, 2L),
+                new Fingerprint(ValueKind.List, 2L),
                 _zero.Fingerprint
             );
             Assert.Equal(
                 new Fingerprint(
-                    ValueType.List,
+                    ValueKind.List,
                     3L,
                     ParseHex("d14952314d5de233ef0dd0a178617f7f07ea082c")
                 ),
@@ -105,7 +105,7 @@ namespace Bencodex.Tests.Types
             );
             Assert.Equal(
                 new Fingerprint(
-                    ValueType.List,
+                    ValueKind.List,
                     18L,
                     ParseHex("16a855873ac787b7c7f2d2d0360119ca4cbb66fe")
                 ),
@@ -113,7 +113,7 @@ namespace Bencodex.Tests.Types
             );
             Assert.Equal(
                 new Fingerprint(
-                    ValueType.List,
+                    ValueKind.List,
                     26L,
                     ParseHex("82daa9e2ff9f01393b718e09ab9fddd9f8c04e2b")
                 ),
@@ -122,7 +122,7 @@ namespace Bencodex.Tests.Types
 
             Assert.Equal(
                 new Fingerprint(
-                    ValueType.List,
+                    ValueKind.List,
                     99L,
                     ParseHex("2b8cb630402d2507bab8484430dfbde931f4e1bc")
                 ),

--- a/Bencodex.Tests/Types/NullTest.cs
+++ b/Bencodex.Tests/Types/NullTest.cs
@@ -16,13 +16,13 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void SingletonFingerprint()
         {
-            Assert.Equal(new Fingerprint(ValueType.Null, 1L), Null.SingletonFingerprint);
+            Assert.Equal(new Fingerprint(ValueKind.Null, 1L), Null.SingletonFingerprint);
         }
 
         [Fact]
         public void Fingerprint()
         {
-            Assert.Equal(new Fingerprint(ValueType.Null, 1L), Null.Value.Fingerprint);
+            Assert.Equal(new Fingerprint(ValueKind.Null, 1L), Null.Value.Fingerprint);
         }
 
         [Fact]
@@ -32,9 +32,9 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
-        public void Type()
+        public void Kind()
         {
-            Assert.Equal(ValueType.Null, Null.Value.Type);
+            Assert.Equal(ValueKind.Null, Null.Value.Kind);
         }
 
         [Theory]

--- a/Bencodex.Tests/Types/TextTest.cs
+++ b/Bencodex.Tests/Types/TextTest.cs
@@ -12,11 +12,11 @@ namespace Bencodex.Tests.Types
         private readonly Text _complex = new Text("new lines and\n\"quotes\" become escaped to \\");
 
         [Fact]
-        public void Type()
+        public void Kind()
         {
-            Assert.Equal(ValueType.Text, _empty.Type);
-            Assert.Equal(ValueType.Text, _nihao.Type);
-            Assert.Equal(ValueType.Text, _complex.Type);
+            Assert.Equal(ValueKind.Text, _empty.Kind);
+            Assert.Equal(ValueKind.Text, _nihao.Kind);
+            Assert.Equal(ValueKind.Text, _complex.Kind);
         }
 
         [Fact]
@@ -30,10 +30,10 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void Fingerprint()
         {
-            Assert.Equal(new Fingerprint(ValueType.Text, 3L), _empty.Fingerprint);
+            Assert.Equal(new Fingerprint(ValueKind.Text, 3L), _empty.Fingerprint);
             Assert.Equal(
                 new Fingerprint(
-                    ValueType.Text,
+                    ValueKind.Text,
                     9L,
                     new byte[] { 0xe4, 0xbd, 0xa0, 0xe5, 0xa5, 0xbd }
                 ),
@@ -41,7 +41,7 @@ namespace Bencodex.Tests.Types
             );
             Assert.Equal(
                 new Fingerprint(
-                    ValueType.Text,
+                    ValueKind.Text,
                     46L,
                     ParseHex("e72dcfd0ae50a80aaa8c1a78b27e2e11bef66488")
                 ),

--- a/Bencodex/Misc/FingerprintComparer.cs
+++ b/Bencodex/Misc/FingerprintComparer.cs
@@ -14,9 +14,9 @@ namespace Bencodex.Misc
         /// <inheritdoc cref="IComparer{T}.Compare(T, T)"/>
         public int Compare(Fingerprint x, Fingerprint y)
         {
-            if (x.Type != y.Type)
+            if (x.Kind != y.Kind)
             {
-                return x.Type < y.Type ? -1 : 1;
+                return x.Kind < y.Kind ? -1 : 1;
             }
 
             int encLenCmp = x.EncodingLength.CompareTo(y.EncodingLength);

--- a/Bencodex/Misc/KeyComparer.cs
+++ b/Bencodex/Misc/KeyComparer.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using Bencodex.Types;
-using ValueType = Bencodex.Types.ValueType;
 
 namespace Bencodex.Misc
 {
@@ -35,7 +34,7 @@ namespace Bencodex.Misc
                 return string.CompareOrdinal(xt.Value, yt.Value);
             }
 
-            return (x.Type == ValueType.Text).CompareTo(y.Type == ValueType.Text);
+            return (x.Kind == ValueKind.Text).CompareTo(y.Kind == ValueKind.Text);
         }
     }
 }

--- a/Bencodex/Types/Binary.cs
+++ b/Bencodex/Types/Binary.cs
@@ -60,9 +60,9 @@ namespace Bencodex.Types
             "method or Binary.ByteArray property instead.")]
         public byte[] Value => ToByteArray();
 
-        /// <inheritdoc cref="IValue.Type"/>
+        /// <inheritdoc cref="IValue.Kind"/>
         [Pure]
-        public ValueType Type => ValueType.Binary;
+        public ValueKind Kind => ValueKind.Binary;
 
         /// <inheritdoc cref="IValue.Fingerprint"/>
         [Pure]
@@ -77,7 +77,7 @@ namespace Bencodex.Types
                             ? ImmutableArray.Create(SHA1.Create().ComputeHash(ToByteArray()))
                             : ByteArray
                     : ImmutableArray<byte>.Empty;
-                return new Fingerprint(Type, EncodingLength, digest);
+                return new Fingerprint(Kind, EncodingLength, digest);
             }
         }
 

--- a/Bencodex/Types/Boolean.cs
+++ b/Bencodex/Types/Boolean.cs
@@ -21,10 +21,10 @@ namespace Bencodex.Types
 
 #pragma warning disable SA1202
         public static readonly Fingerprint TrueFingerprint =
-            new Fingerprint(ValueType.Boolean, 1L, new byte[] { 1 });
+            new Fingerprint(ValueKind.Boolean, 1L, new byte[] { 1 });
 
         public static readonly Fingerprint FalseFingerprint =
-            new Fingerprint(ValueType.Boolean, 1L, new byte[] { 0 });
+            new Fingerprint(ValueKind.Boolean, 1L, new byte[] { 0 });
 #pragma warning restore SA1202
 
         public Boolean(bool value)
@@ -34,9 +34,9 @@ namespace Bencodex.Types
 
         public bool Value { get; }
 
-        /// <inheritdoc cref="IValue.Type"/>
+        /// <inheritdoc cref="IValue.Kind"/>
         [Pure]
-        public ValueType Type => ValueType.Boolean;
+        public ValueKind Kind => ValueKind.Boolean;
 
         /// <inheritdoc cref="IValue.Fingerprint"/>
         [Pure]

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -483,11 +483,12 @@ namespace Bencodex.Types
             return (T)this[name];
         }
 
+        /// <inheritdoc cref="object.Equals(object)"/>
         public override bool Equals(object obj) =>
             obj switch
             {
                 null => false,
-                Dictionary d => this.Equals(d),
+                Dictionary d => Equals(d),
                 _ => false
             };
 
@@ -504,17 +505,26 @@ namespace Bencodex.Types
             {
                 return false;
             }
-
-            foreach (KeyValuePair<IKey, IValue> kv in this)
+            else if (other is Dictionary od)
             {
-                if (!other.TryGetValue(kv.Key, out IValue v) ||
-                    !v.Equals(kv.Value))
+                return od.Fingerprint.Equals(Fingerprint);
+            }
+
+            foreach (KeyValuePair<IKey, IndirectValue> kv in _dict)
+            {
+                if (!other.TryGetValue(kv.Key, out IValue v))
+                {
+                    return false;
+                }
+
+                if (kv.Value.LoadedValue is { } loaded
+                        ? !loaded.Equals(v)
+                        : !kv.Value.Fingerprint.Equals(v.Fingerprint))
                 {
                     return false;
                 }
             }
 
-            _loader = null;
             return true;
         }
 

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -32,7 +32,7 @@ namespace Bencodex.Types
         /// The singleton fingerprint for empty dictionaries.
         /// </summary>
         public static readonly Fingerprint EmptyFingerprint =
-            new Fingerprint(ValueType.Dictionary, 2);
+            new Fingerprint(ValueKind.Dictionary, 2);
 
         private static readonly byte[] _dictionaryPrefix = new byte[1] { 0x64 };  // 'd'
 
@@ -113,8 +113,8 @@ namespace Bencodex.Types
             }
         }
 
-        /// <inheritdoc cref="IValue.Type"/>
-        public ValueType Type => ValueType.Dictionary;
+        /// <inheritdoc cref="IValue.Kind"/>
+        public ValueKind Kind => ValueKind.Dictionary;
 
         /// <inheritdoc cref="IValue.Fingerprint"/>
         public Fingerprint Fingerprint
@@ -150,7 +150,7 @@ namespace Bencodex.Types
                     }
                 }
 
-                return new Fingerprint(Type, EncodingLength, hash);
+                return new Fingerprint(Kind, EncodingLength, hash);
             }
         }
 
@@ -545,7 +545,7 @@ namespace Bencodex.Types
 
             foreach (KeyValuePair<IKey, IValue> pair in this)
             {
-                if (pair.Key.Type == ValueType.Text)
+                if (pair.Key.Kind == ValueKind.Text)
                 {
                     yield return _unicodeKeyPrefix;
                     length += _unicodeKeyPrefix.LongLength;
@@ -582,7 +582,7 @@ namespace Bencodex.Types
 
             foreach (KeyValuePair<IKey, IValue> pair in this)
             {
-                if (pair.Key.Type == ValueType.Text)
+                if (pair.Key.Kind == ValueKind.Text)
                 {
                     stream.WriteByte(_unicodeKeyPrefix[0]);
                 }

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -231,6 +231,13 @@ namespace Bencodex.Types
         /// <inheritdoc cref="IEnumerable.GetEnumerator()"/>
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
+        /// <summary>
+        /// Enumerates pairs of keys and <see cref="IndirectValue"/>s in the dictionary.
+        /// </summary>
+        /// <returns>An enumerable of pairs of keys and <see cref="IndirectValue"/>s, which can be
+        /// either loaded or offloaded.</returns>
+        public IEnumerable<KeyValuePair<IKey, IndirectValue>> EnumerateIndirectValues() => _dict;
+
         /// <inheritdoc cref="IReadOnlyDictionary{TKey,TValue}.ContainsKey(TKey)"/>
         public bool ContainsKey(IKey key) => _dict.ContainsKey(key);
 

--- a/Bencodex/Types/Fingerprint.cs
+++ b/Bencodex/Types/Fingerprint.cs
@@ -17,27 +17,27 @@ namespace Bencodex.Types
         /// <summary>
         /// Creates a <see cref="Fingerprint"/> value.
         /// </summary>
-        /// <param name="type">The value type.</param>
+        /// <param name="kind">The Bencodex type of the value.</param>
         /// <param name="encodingLength">The byte length of encoded value.</param>
-        public Fingerprint(in ValueType type, in long encodingLength)
-            : this(type, encodingLength, ImmutableArray<byte>.Empty)
+        public Fingerprint(in ValueKind kind, in long encodingLength)
+            : this(kind, encodingLength, ImmutableArray<byte>.Empty)
         {
         }
 
         /// <summary>
         /// Creates a <see cref="Fingerprint"/> value.
         /// </summary>
-        /// <param name="type">The value type.</param>
+        /// <param name="kind">The Bencodex type of the value.</param>
         /// <param name="encodingLength">The byte length of encoded value.</param>
         /// <param name="digest">The digest of the value.  It can be empty, but cannot be
         /// <c>null</c>.</param>
         public Fingerprint(
-            in ValueType type,
+            in ValueKind kind,
             in long encodingLength,
             IReadOnlyList<byte> digest
         )
             : this(
-                type,
+                kind,
                 encodingLength,
                 digest is ImmutableArray<byte> ia ? ia : ImmutableArray.CreateRange(digest)
             )
@@ -47,24 +47,24 @@ namespace Bencodex.Types
         /// <summary>
         /// Creates a <see cref="Fingerprint"/> value.
         /// </summary>
-        /// <param name="type">The value type.</param>
+        /// <param name="kind">The Bencodex type of the value.</param>
         /// <param name="encodingLength">The byte length of encoded value.</param>
         /// <param name="digest">The digest of the value.  It can be empty, but cannot be
         /// <c>null</c>.</param>
         public Fingerprint(
-            in ValueType type,
+            in ValueKind kind,
             in long encodingLength,
             in ImmutableArray<byte> digest
         )
         {
-            Type = type;
+            Kind = kind;
             EncodingLength = encodingLength;
             Digest = digest;
         }
 
         private Fingerprint(SerializationInfo info, StreamingContext context)
             : this(
-                (ValueType)info.GetByte(nameof(Type)),
+                (ValueKind)info.GetByte(nameof(Kind)),
                 info.GetInt64(nameof(EncodingLength)),
                 (byte[])info.GetValue(nameof(Digest), typeof(byte[]))
             )
@@ -72,10 +72,10 @@ namespace Bencodex.Types
         }
 
         /// <summary>
-        /// The value type.
+        /// The Bencodex type of the value.
         /// </summary>
         [Pure]
-        public ValueType Type { get; }
+        public ValueKind Kind { get; }
 
         /// <summary>
         /// The byte length of encoded value.
@@ -126,14 +126,14 @@ namespace Bencodex.Types
                 throw new FormatException("The serialized bytes is not valid.");
             }
 
-            var type = (ValueType)serialized[0];
+            var kind = (ValueKind)serialized[0];
             if (BitConverter.IsLittleEndian)
             {
                 Array.Reverse(serialized, 1, 8);
             }
 
             return new Fingerprint(
-                type,
+                kind,
                 BitConverter.ToInt64(serialized, 1),
                 serialized.Skip(1 + 8).ToImmutableArray()
             );
@@ -143,7 +143,7 @@ namespace Bencodex.Types
         [Pure]
         public bool Equals(Fingerprint other)
         {
-            if (Type != other.Type ||
+            if (Kind != other.Kind ||
                 EncodingLength != other.EncodingLength ||
                 Digest.Length != other.Digest.Length)
             {
@@ -172,7 +172,7 @@ namespace Bencodex.Types
         {
             unchecked
             {
-                var hashCode = (int)Type;
+                var hashCode = (int)Kind;
                 hashCode = (hashCode * 397) ^ EncodingLength.GetHashCode();
                 foreach (byte b in Digest)
                 {
@@ -208,7 +208,7 @@ namespace Bencodex.Types
             }
 
             var total = new byte[1 + encLength.Length + hash.Length];
-            total[0] = (byte)Type;
+            total[0] = (byte)Kind;
             encLength.CopyTo(total, 1);
             hash.CopyTo(total, 1 + encLength.Length);
             return total;
@@ -217,13 +217,13 @@ namespace Bencodex.Types
         /// <inheritdoc cref="ISerializable.GetObjectData(SerializationInfo, StreamingContext)"/>
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
-            info.AddValue(nameof(Type), (byte)Type);
+            info.AddValue(nameof(Kind), (byte)Kind);
             info.AddValue(nameof(EncodingLength), EncodingLength);
             info.AddValue(nameof(Digest), GetDigest());
         }
 
         /// <inheritdoc cref="object.ToString()"/>
         public override string ToString() =>
-            $"{Type} {(Digest.Any() ? $"{Digest.Hex()} " : string.Empty)}[{EncodingLength} B]";
+            $"{Kind} {(Digest.Any() ? $"{Digest.Hex()} " : string.Empty)}[{EncodingLength} B]";
     }
 }

--- a/Bencodex/Types/IValue.cs
+++ b/Bencodex/Types/IValue.cs
@@ -20,7 +20,7 @@ namespace Bencodex.Types
         /// The Bencodex type identifier.
         /// </summary>
         [Pure]
-        ValueType Type { get; }
+        ValueKind Kind { get; }
 
         /// <summary>
         /// A unique identifier of the value.  Can be used for efficient determining of two values

--- a/Bencodex/Types/IndirectValue.cs
+++ b/Bencodex/Types/IndirectValue.cs
@@ -60,7 +60,7 @@ namespace Bencodex.Types
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown when the <see cref="IndirectValue"/>
         /// is an uninitialized default value.</exception>
-        public ValueType Type => LoadedValue is { } loaded ? loaded.Type : Fingerprint.Type;
+        public ValueKind Type => LoadedValue is { } loaded ? loaded.Kind : Fingerprint.Kind;
 
         /// <summary>
         /// The encoding length of the value that this <see cref="IndirectValue"/> refers to.

--- a/Bencodex/Types/Integer.cs
+++ b/Bencodex/Types/Integer.cs
@@ -61,9 +61,9 @@ namespace Bencodex.Types
 
         public BigInteger Value { get; }
 
-        /// <inheritdoc cref="IValue.Type"/>
+        /// <inheritdoc cref="IValue.Kind"/>
         [Pure]
-        public ValueType Type => ValueType.Integer;
+        public ValueKind Kind => ValueKind.Integer;
 
         /// <inheritdoc cref="IValue.Fingerprint"/>
         [Pure]
@@ -76,7 +76,7 @@ namespace Bencodex.Types
                 byte[] bytes = Value.ToByteArray();
                 IReadOnlyList<byte> digest =
                     bytes.Length <= 20 ? bytes : SHA1.Create().ComputeHash(bytes);
-                return new Fingerprint(Type, EncodingLength, digest);
+                return new Fingerprint(Kind, EncodingLength, digest);
             }
         }
 

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -178,8 +178,8 @@ namespace Bencodex.Types
             return true;
         }
 
-        public bool Equals(List other) =>
-            ((IEquatable<IImmutableList<IValue>>)this).Equals(other);
+        /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
+        public bool Equals(List other) => Fingerprint.Equals(other.Fingerprint);
 
         bool IEquatable<IValue>.Equals(IValue other) =>
             other is List o && Equals(o);

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -30,7 +30,7 @@ namespace Bencodex.Types
         /// The singleton fingerprint for empty lists.
         /// </summary>
         public static readonly Fingerprint EmptyFingerprint =
-            new Fingerprint(ValueType.List, 2L);
+            new Fingerprint(ValueKind.List, 2L);
 
         private static readonly byte[] _listPrefix = new byte[1] { 0x6c };  // 'l'
 
@@ -85,9 +85,9 @@ namespace Bencodex.Types
             _hash = null;
         }
 
-        /// <inheritdoc cref="IValue.Type"/>
+        /// <inheritdoc cref="IValue.Kind"/>
         [Pure]
-        public ValueType Type => ValueType.List;
+        public ValueKind Kind => ValueKind.List;
 
         /// <inheritdoc cref="IValue.Fingerprint"/>
         [Pure]
@@ -122,7 +122,7 @@ namespace Bencodex.Types
                     }
                 }
 
-                return new Fingerprint(Type, EncodingLength, hash);
+                return new Fingerprint(Kind, EncodingLength, hash);
             }
         }
 
@@ -408,7 +408,7 @@ namespace Bencodex.Types
 
                 case 1:
                     IndirectValue first = _values[0];
-                    if (first.Type == ValueType.List || first.Type == ValueType.Dictionary)
+                    if (first.Type == ValueKind.List || first.Type == ValueKind.Dictionary)
                     {
                         goto default;
                     }

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -194,16 +194,16 @@ namespace Bencodex.Types
             _loader = null;
         }
 
-        public override bool Equals(object obj)
-        {
-            if (ReferenceEquals(null, obj))
-            {
-                return false;
-            }
+        /// <summary>
+        /// Enumerates <see cref="IndirectValue"/>s in the list.
+        /// </summary>
+        /// <returns>An enumerable of <see cref="IndirectValue"/>s, which can be either loaded or
+        /// offloaded.</returns>
+        public IEnumerable<IndirectValue> EnumerateIndirectValues() => _values;
 
-            return obj is List other &&
-                ((IEquatable<IImmutableList<IValue>>)this).Equals(other);
-        }
+        /// <inheritdoc cref="object.Equals(object?)"/>
+        public override bool Equals(object? obj) => obj is List other &&
+            ((IEquatable<IImmutableList<IValue>>)this).Equals(other);
 
         /// <inheritdoc cref="object.GetHashCode()"/>
         public override int GetHashCode() =>

--- a/Bencodex/Types/Null.cs
+++ b/Bencodex/Types/Null.cs
@@ -25,11 +25,11 @@ namespace Bencodex.Types
         /// The singleton fingerprint for the <see cref="Null"/> value.
         /// </summary>
         public static readonly Fingerprint SingletonFingerprint =
-            new Fingerprint(ValueType.Null, 1L);
+            new Fingerprint(ValueKind.Null, 1L);
 
-        /// <inheritdoc cref="IValue.Type"/>
+        /// <inheritdoc cref="IValue.Kind"/>
         [Pure]
-        public ValueType Type => ValueType.Null;
+        public ValueKind Kind => ValueKind.Null;
 
         /// <inheritdoc cref="IValue.Fingerprint"/>
         [Pure]

--- a/Bencodex/Types/Text.cs
+++ b/Bencodex/Types/Text.cs
@@ -37,9 +37,9 @@ namespace Bencodex.Types
         [Pure]
         byte? IKey.KeyPrefix => _keyPrefix;  // 'u'
 
-        /// <inheritdoc cref="IValue.Type"/>
+        /// <inheritdoc cref="IValue.Kind"/>
         [Pure]
-        public ValueType Type => ValueType.Text;
+        public ValueKind Kind => ValueKind.Text;
 
         /// <inheritdoc cref="IValue.Fingerprint"/>
         [Pure]
@@ -66,7 +66,7 @@ namespace Bencodex.Types
                     }
                 }
 
-                return new Fingerprint(Type, EncodingLength, digest);
+                return new Fingerprint(Kind, EncodingLength, digest);
             }
         }
 

--- a/Bencodex/Types/ValueKind.cs
+++ b/Bencodex/Types/ValueKind.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// The value to identify types of Bencodex values.
     /// </summary>
-    public enum ValueType : byte
+    public enum ValueKind : byte
     {
         /// <summary>
         /// Null (<c>n</c>).

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ To be released.
     interface.  [[#52]]
  -  `Bencodex.Types.Dictionary` class now implements
     `IEquatable<Bencodex.Types.Dictionary>` interface.  [[#51]]
- -  Added `Bencodex.Types.ValueType` enum type.  [[#50]]
+ -  Added `Bencodex.Types.ValueKind` enum type.  [[#50], [#53]]
  -  Bencodex lists and dictionaries now can offload their elements:  [[#52]]
      -  Added `Bencodex.Types.IndirectValue` struct.
      -  Added `List(IEnumerable<IndirectValue>, IndirectValue.Loader)`
@@ -29,7 +29,7 @@ To be released.
      -  Added `Boolean.FalseFingerprint` static readonly field.
      -  Added `List.EmptyFingerprint` static readonly field.
      -  Added `Dictionary.EmptyFingerprint` static readonly field.
- -  Added `IValue.Type` property.  [[#50]]
+ -  Added `IValue.Kind` property.  [[#50], [#53]]
  -  Added `IValue.EncodingLength` property.  [[#49], [#50]]
  -  Added `IValue.Inspect(bool)` method to replace `IValue.Inspection` property.
     [[#52]]
@@ -53,6 +53,7 @@ To be released.
 [#50]: https://github.com/planetarium/bencodex.net/pull/50
 [#51]: https://github.com/planetarium/bencodex.net/pull/51
 [#52]: https://github.com/planetarium/bencodex.net/pull/52
+[#53]: https://github.com/planetarium/bencodex.net/pull/53
 
 
 Version 0.3.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,12 +14,14 @@ To be released.
  -  `Bencodex.Types.Dictionary` class now implements
     `IEquatable<Bencodex.Types.Dictionary>` interface.  [[#51]]
  -  Added `Bencodex.Types.ValueKind` enum type.  [[#50], [#53]]
- -  Bencodex lists and dictionaries now can offload their elements:  [[#52]]
-     -  Added `Bencodex.Types.IndirectValue` struct.
+ -  Bencodex lists and dictionaries now can offload their elements:
+     -  Added `Bencodex.Types.IndirectValue` struct.  [[#52]]
      -  Added `List(IEnumerable<IndirectValue>, IndirectValue.Loader)`
-        constructor.
+        constructor.  [[#52]]
      -  Added `Dictionary(IEnumerable<KeyValuePair<IKey, IndirectValue>>,
-        IndirectValue.Loader)` constructor.
+        IndirectValue.Loader)` constructor.  [[#52]]
+     -  Added `List.EnumerateIndirectValues()` method.  [[#53]]
+     -  Added `Dictionary.EnumerateIndirectValues()` method.  [[#53]]
  -  Bencodex values now have their unique fingerprints:  [[#50]]
      -  Added `Bencodex.Types.Fingerprint` readonly struct.
      -  Added `Bencodex.Misc.FingerprintComparer` class.


### PR DESCRIPTION
It is continued from the previous patch <https://github.com/planetarium/bencodex.net/pull/52>, and addresses <https://github.com/planetarium/bencodex.net/pull/52#pullrequestreview-810657314> in particular.

This patch simply makes `List` & `Dictionary` to expose its internal `IndirectValue`s so that loaded values and offloaded values are serialized/stored in different ways.

Plus, I renamed `ValueType` to `ValueKind` to disambiguate it from [`System.ValueType`][1].

[1]: https://docs.microsoft.com/en-us/dotnet/api/system.valuetype?view=netstandard-2.0