### PR TITLE
Faster encoding: ×4 for `byte[]` & ×1,000 for `Stream`

### DIFF
--- a/Bencodex/Codec.cs
+++ b/Bencodex/Codec.cs
@@ -43,7 +43,10 @@ namespace Bencodex
                 );
             }
 
-            value.EncodeToStream(output);
+            foreach (byte[] chunk in value.EncodeIntoChunks())
+            {
+                output.Write(chunk, 0, chunk.Length);
+            }
         }
 
         /// <summary>Decodes an encoded value from an <paramref name="input"/>

--- a/Bencodex/Codec.cs
+++ b/Bencodex/Codec.cs
@@ -20,12 +20,7 @@ namespace Bencodex
         /// contains the whole Bencodex representation of
         /// the <paramref name="value"/>.</returns>
         [Pure]
-        public byte[] Encode(IValue value)
-        {
-            var stream = new MemoryStream();
-            Encode(value, stream);
-            return stream.ToArray();
-        }
+        public byte[] Encode(IValue value) => Encoder.Encode(value);
 
         /// <summary>Encodes a <paramref name="value"/>,
         /// and write it on an <paramref name="output"/> stream.</summary>
@@ -33,21 +28,7 @@ namespace Bencodex
         /// <param name="output">A stream that a value is printed on.</param>
         /// <exception cref="ArgumentException">Thrown when a given
         /// <paramref name="output"/> stream is not writable.</exception>
-        public void Encode(IValue value, Stream output)
-        {
-            if (!output.CanWrite)
-            {
-                throw new ArgumentException(
-                    "stream cannot be written to",
-                    nameof(output)
-                );
-            }
-
-            foreach (byte[] chunk in value.EncodeIntoChunks())
-            {
-                output.Write(chunk, 0, chunk.Length);
-            }
-        }
+        public void Encode(IValue value, Stream output) => Encoder.Encode(value, output);
 
         /// <summary>Decodes an encoded value from an <paramref name="input"/>
         /// stream.</summary>

--- a/Bencodex/Encoder.cs
+++ b/Bencodex/Encoder.cs
@@ -1,0 +1,218 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using Bencodex.Types;
+
+namespace Bencodex
+{
+    internal static class Encoder
+    {
+        public static byte[] Encode(IValue value)
+        {
+            var buffer = new byte[value.EncodingLength];
+            Encode(value, buffer, 0L);
+            return buffer;
+        }
+
+        public static void Encode(IValue value, Stream output)
+        {
+            if (!output.CanWrite)
+            {
+                throw new ArgumentException(
+                    "stream cannot be written to",
+                    nameof(output)
+                );
+            }
+
+            if (value.EncodingLength > 4096L)
+            {
+                switch (value)
+                {
+                    case List l:
+                        output.WriteByte(0x6c);  // 'l'
+                        foreach (IValue el in l)
+                        {
+                            Encode(el, output);
+                        }
+
+                        output.WriteByte(0x65);  // 'e'
+                        break;
+
+                    case Dictionary d:
+                        output.WriteByte(0x6c);  // 'l'
+                        foreach (KeyValuePair<IKey, IValue> pair in d)
+                        {
+                            Encode(pair.Key, output);
+                            Encode(pair.Value, output);
+                        }
+
+                        output.WriteByte(0x65);  // 'e'
+                        break;
+                }
+
+                return;
+            }
+
+            byte[] buffer = Encode(value);
+            output.Write(buffer, 0, buffer.Length);
+        }
+
+        private static long EncodeNull(in Null value, byte[] buffer, long offset)
+        {
+            buffer[offset] = 0x6e;  // 'n'
+            return 1L;
+        }
+
+        private static long EncodeBoolean(in Types.Boolean value, byte[] buffer, long offset)
+        {
+            buffer[offset] = value.Value
+                ? (byte)0x74 // 't'
+                : (byte)0x66; // 'f'
+            return 1L;
+        }
+
+        private static long EncodeInteger(in Integer value, byte[] buffer, long offset)
+        {
+            buffer[offset] = 0x69;  // 'i'
+            offset++;
+            string digits = value.Value.ToString(CultureInfo.InvariantCulture);
+            if (buffer.LongLength < offset + digits.Length + 1L)
+            {
+                throw new IndexOutOfRangeException("The " + nameof(buffer) + " is not enough.");
+            }
+
+            if (offset + digits.Length <= int.MaxValue)
+            {
+                Encoding.ASCII.GetBytes(digits, 0, digits.Length, buffer, (int)offset);
+            }
+            else
+            {
+                byte[] digitBytes = Encoding.ASCII.GetBytes(digits);
+                Array.Copy(digitBytes, 0L, buffer, offset, digitBytes.LongLength);
+            }
+
+            offset += digits.Length;
+            buffer[offset] = 0x65;  // 'e'
+            return 1L + digits.Length + 1L;
+        }
+
+        private static long EncodeBinary(in Binary value, byte[] buffer, long offset)
+        {
+            int len = value.ByteArray.Length;
+            string lenStr = len.ToString(CultureInfo.InvariantCulture);
+            long lenStrLength = lenStr.Length;
+            if (offset + lenStrLength <= int.MaxValue)
+            {
+                lenStrLength = Encoding.ASCII.GetBytes(lenStr, 0, lenStr.Length, buffer, (int)offset);
+            }
+            else
+            {
+                byte[] lenStrBytes = Encoding.ASCII.GetBytes(lenStr);
+                lenStrLength = lenStrBytes.LongLength;
+                Array.Copy(lenStrBytes, 0L, buffer, offset, lenStrLength);
+            }
+
+            offset += lenStrLength;
+            buffer[offset] = 0x3a;  // ':'
+            offset++;
+
+            if (offset + len <= int.MaxValue)
+            {
+                value.ByteArray.CopyTo(buffer, (int)offset);
+                return lenStrLength + 1L + len;
+            }
+
+            byte[] b = value.ToByteArray();
+            Array.Copy(b, 0L, buffer, offset, b.LongLength);
+            return lenStrLength + 1L + b.LongLength;
+        }
+
+        private static long EncodeText(in Text value, byte[] buffer, long offset)
+        {
+            buffer[offset++] = 0x75;  // 'u'
+            int utf8Length = value.Utf8Length;
+            string lenStr = utf8Length.ToString(CultureInfo.InvariantCulture);
+            long lenStrLength = lenStr.Length;
+            if (offset + lenStr.Length <= int.MaxValue)
+            {
+                lenStrLength = Encoding.ASCII.GetBytes(lenStr, 0, lenStr.Length, buffer, (int)offset);
+            }
+            else
+            {
+                byte[] lenStrBytes = Encoding.ASCII.GetBytes(lenStr);
+                lenStrLength = lenStrBytes.LongLength;
+                Array.Copy(lenStrBytes, 0L, buffer, offset, lenStrLength);
+            }
+
+            offset += lenStrLength;
+            buffer[offset] = 0x3a;  // ':'
+            offset++;
+            string str = value.Value;
+
+            if (offset + str.Length <= int.MaxValue)
+            {
+                Encoding.UTF8.GetBytes(str, 0, str.Length, buffer, (int)offset);
+                return 1L + lenStrLength + 1L + utf8Length;
+            }
+
+            byte[] utf8 = Encoding.UTF8.GetBytes(value.Value);
+            Array.Copy(utf8, 0L, buffer, offset, utf8.LongLength);
+            return 1L + lenStrLength + 1L + utf8.LongLength;
+        }
+
+        private static long EncodeList(in List value, byte[] buffer, long offset)
+        {
+            buffer[offset] = 0x6c;  // 'l'
+            long encLen = 1L;
+            foreach (IValue el in value)
+            {
+                encLen += Encode(el, buffer, offset + encLen);
+            }
+
+            offset += encLen;
+            buffer[offset] = 0x65;  // 'e'
+            encLen++;
+            value.EncodingLength = encLen;
+            return encLen;
+        }
+
+        private static long EncodeDictionary(in Dictionary value, byte[] buffer, long offset)
+        {
+            buffer[offset] = 0x64;  // 'd'
+            long encLen = 1L;
+            foreach (KeyValuePair<IKey, IValue> pair in value)
+            {
+                encLen += pair.Key switch
+                {
+                    Text tk => EncodeText(tk, buffer, offset + encLen),
+                    Binary bk => EncodeBinary(bk, buffer, offset + encLen),
+                    { } k => Encode(k, buffer, offset + encLen),
+                };
+                encLen += Encode(pair.Value, buffer, offset + encLen);
+            }
+
+            offset += encLen;
+            buffer[offset] = 0x65;  // 'e'
+            encLen++;
+            value.EncodingLength = encLen;
+            return encLen;
+        }
+
+        private static long Encode(in IValue value, byte[] buffer, long offset)
+        {
+            return value switch
+            {
+                Null n => EncodeNull(n, buffer, offset),
+                Types.Boolean b => EncodeBoolean(b, buffer, offset),
+                Integer i => EncodeInteger(i, buffer, offset),
+                Binary bin => EncodeBinary(bin, buffer, offset),
+                Text t => EncodeText(t, buffer, offset),
+                List l => EncodeList(l, buffer, offset),
+                Dictionary d => EncodeDictionary(d, buffer, offset),
+                _ => throw new ArgumentException("Unsupported type: " + value.GetType().FullName, nameof(value)),
+            };
+        }
+    }
+}

--- a/Bencodex/Types/Binary.cs
+++ b/Bencodex/Types/Binary.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -207,15 +206,6 @@ namespace Bencodex.Types
         [Pure]
         byte[] IKey.EncodeAsByteArray() =>
             ToByteArray();
-
-        [Pure]
-        public IEnumerable<byte[]> EncodeIntoChunks()
-        {
-            string len = ByteArray.Length.ToString(CultureInfo.InvariantCulture);
-            yield return Encoding.ASCII.GetBytes(len);
-            yield return CommonVariables.Separator;  // ':'
-            yield return ((IKey)this).EncodeAsByteArray();
-        }
 
         [Pure]
         public byte[] ToByteArray()

--- a/Bencodex/Types/Binary.cs
+++ b/Bencodex/Types/Binary.cs
@@ -204,10 +204,6 @@ namespace Bencodex.Types
             ((IEnumerable)ByteArray).GetEnumerator();
 
         [Pure]
-        byte[] IKey.EncodeAsByteArray() =>
-            ToByteArray();
-
-        [Pure]
         public byte[] ToByteArray()
         {
             if (ByteArray.IsDefaultOrEmpty)

--- a/Bencodex/Types/Binary.cs
+++ b/Bencodex/Types/Binary.cs
@@ -49,9 +49,6 @@ namespace Bencodex.Types
         {
         }
 
-        [Pure]
-        byte? IKey.KeyPrefix => null;
-
         public ImmutableArray<byte> ByteArray =>
             _value.IsDefaultOrEmpty ? ImmutableArray<byte>.Empty : _value;
 

--- a/Bencodex/Types/Binary.cs
+++ b/Bencodex/Types/Binary.cs
@@ -220,16 +220,6 @@ namespace Bencodex.Types
             yield return ((IKey)this).EncodeAsByteArray();
         }
 
-        public void EncodeToStream(Stream stream)
-        {
-            byte[] value = ToByteArray();
-            string len = value.Length.ToString(CultureInfo.InvariantCulture);
-            byte[] lenBytes = Encoding.ASCII.GetBytes(len);
-            stream.Write(lenBytes, 0, lenBytes.Length);
-            stream.WriteByte(CommonVariables.Separator[0]);
-            stream.Write(value, 0, value.Length);
-        }
-
         [Pure]
         public byte[] ToByteArray()
         {

--- a/Bencodex/Types/Boolean.cs
+++ b/Bencodex/Types/Boolean.cs
@@ -123,12 +123,6 @@ namespace Bencodex.Types
             }
         }
 
-        public void EncodeToStream(Stream stream)
-        {
-            var value = Value ? _true[0] : _false[0];
-            stream.WriteByte(value);
-        }
-
         /// <inheritdoc cref="IValue.Inspect(bool)"/>
         public string Inspect(bool loadAll) =>
             Value ? "true" : "false";

--- a/Bencodex/Types/Boolean.cs
+++ b/Bencodex/Types/Boolean.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.Contracts;
-using System.IO;
 
 namespace Bencodex.Types
 {
@@ -15,10 +13,6 @@ namespace Bencodex.Types
         IComparable<Boolean>,
         IComparable
     {
-        private static readonly byte[] _true = new byte[1] { 0x74 };  // 't'
-
-        private static readonly byte[] _false = new byte[1] { 0x66 };  // 'f'
-
 #pragma warning disable SA1202
         public static readonly Fingerprint TrueFingerprint =
             new Fingerprint(ValueKind.Boolean, 1L, new byte[] { 1 });
@@ -108,19 +102,6 @@ namespace Bencodex.Types
         public override int GetHashCode()
         {
             return Value.GetHashCode();
-        }
-
-        [Pure]
-        public IEnumerable<byte[]> EncodeIntoChunks()
-        {
-            if (Value)
-            {
-                yield return _true;
-            }
-            else
-            {
-                yield return _false;
-            }
         }
 
         /// <inheritdoc cref="IValue.Inspect(bool)"/>

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -546,7 +546,6 @@ namespace Bencodex.Types
         /// <inheritdoc cref="IValue.EncodeIntoChunks()"/>
         public IEnumerable<byte[]> EncodeIntoChunks()
         {
-            // FIXME: avoid duplication between this and EncodeToStream()
             long length = _dictionaryPrefix.LongLength;
             yield return _dictionaryPrefix;
 
@@ -578,34 +577,6 @@ namespace Bencodex.Types
             yield return CommonVariables.Suffix;
             length += CommonVariables.Suffix.Length;
             _encodingLength = length;
-        }
-
-        /// <inheritdoc cref="IValue.EncodeToStream(Stream)"/>
-        public void EncodeToStream(Stream stream)
-        {
-            // FIXME: avoid duplication between this and EncodeIntoChunks()
-            long startPos = stream.Position;
-            stream.WriteByte(_dictionaryPrefix[0]);
-
-            foreach (KeyValuePair<IKey, IValue> pair in this)
-            {
-                if (pair.Key.Kind == ValueKind.Text)
-                {
-                    stream.WriteByte(_unicodeKeyPrefix[0]);
-                }
-
-                byte[] key = pair.Key.EncodeAsByteArray();
-                var keyLen =
-                    key.Length.ToString(CultureInfo.InvariantCulture);
-                var keyLenBytes = Encoding.ASCII.GetBytes(keyLen);
-                stream.Write(keyLenBytes, 0, keyLenBytes.Length);
-                stream.WriteByte(CommonVariables.Separator[0]);
-                stream.Write(key, 0, key.Length);
-                pair.Value.EncodeToStream(stream);
-            }
-
-            stream.WriteByte(CommonVariables.Suffix[0]);
-            _encodingLength = stream.Position - startPos;
         }
 
         /// <inheritdoc cref="IValue.Inspect(bool)"/>

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -3,11 +3,8 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
-using System.Globalization;
-using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
 using Bencodex.Misc;
 
 namespace Bencodex.Types
@@ -26,7 +23,10 @@ namespace Bencodex.Types
         /// The empty dictionary.
         /// </summary>
         public static readonly Dictionary Empty =
-            new Dictionary(ImmutableDictionary<IKey, IValue>.Empty);
+            new Dictionary(ImmutableDictionary<IKey, IValue>.Empty)
+            {
+                EncodingLength = 2L,
+            };
 
         /// <summary>
         /// The singleton fingerprint for empty dictionaries.
@@ -34,14 +34,10 @@ namespace Bencodex.Types
         public static readonly Fingerprint EmptyFingerprint =
             new Fingerprint(ValueKind.Dictionary, 2);
 
-        private static readonly byte[] _dictionaryPrefix = new byte[1] { 0x64 };  // 'd'
-
-        private static readonly byte[] _unicodeKeyPrefix = new byte[1] { 0x75 };  // 'u'
-
         private readonly ImmutableSortedDictionary<IKey, IndirectValue> _dict;
         private IndirectValue.Loader? _loader;
         private ImmutableArray<byte>? _hash;
-        private long _encodingLength = -1;
+        private long _encodingLength = -1L;
 
         /// <summary>
         /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
@@ -155,12 +151,17 @@ namespace Bencodex.Types
         }
 
         /// <inheritdoc cref="IValue.EncodingLength"/>
-        public long EncodingLength =>
-            _encodingLength >= 0
-                ? _encodingLength
-                : _encodingLength = _dictionaryPrefix.LongLength
-                    + _dict.Sum(kv => kv.Key.EncodingLength + kv.Value.EncodingLength)
-                    + CommonVariables.Suffix.LongLength;
+        public long EncodingLength
+        {
+            get =>
+                _encodingLength < 2L
+                    ? _encodingLength = 1L
+                                        + _dict.Sum(kv =>
+                                            kv.Key.EncodingLength + kv.Value.EncodingLength)
+                                        + CommonVariables.Suffix.LongLength
+                    : _encodingLength;
+            internal set => _encodingLength = value;
+        }
 
         /// <inheritdoc cref="IValue.Inspection"/>
         [Obsolete("Deprecated in favour of " + nameof(Inspect) + "() method.")]
@@ -542,42 +543,6 @@ namespace Bencodex.Types
 
         /// <inheritdoc cref="object.GetHashCode()"/>
         public override int GetHashCode() => _dict.GetHashCode();
-
-        /// <inheritdoc cref="IValue.EncodeIntoChunks()"/>
-        public IEnumerable<byte[]> EncodeIntoChunks()
-        {
-            long length = _dictionaryPrefix.LongLength;
-            yield return _dictionaryPrefix;
-
-            foreach (KeyValuePair<IKey, IValue> pair in this)
-            {
-                if (pair.Key.Kind == ValueKind.Text)
-                {
-                    yield return _unicodeKeyPrefix;
-                    length += _unicodeKeyPrefix.LongLength;
-                }
-
-                byte[] key = pair.Key.EncodeAsByteArray();
-                byte[] keyLengthBytes = Encoding.ASCII.GetBytes(
-                    key.Length.ToString(CultureInfo.InvariantCulture)
-                );
-                yield return keyLengthBytes;
-                length += keyLengthBytes.LongLength;
-                yield return CommonVariables.Separator;
-                length += CommonVariables.Separator.LongLength;
-                yield return key;
-                length += key.LongLength;
-                foreach (byte[] chunk in pair.Value.EncodeIntoChunks())
-                {
-                    yield return chunk;
-                    length += chunk.LongLength;
-                }
-            }
-
-            yield return CommonVariables.Suffix;
-            length += CommonVariables.Suffix.Length;
-            _encodingLength = length;
-        }
 
         /// <inheritdoc cref="IValue.Inspect(bool)"/>
         public string Inspect(bool loadAll)

--- a/Bencodex/Types/IKey.cs
+++ b/Bencodex/Types/IKey.cs
@@ -2,11 +2,13 @@ using System.Diagnostics.Contracts;
 
 namespace Bencodex.Types
 {
+    /// <summary>
+    /// Represents Bencodex values which can be keys of a Bencodex <see cref="Dictionary"/>.
+    /// </summary>
+    /// <seealso cref="Binary"/>
+    /// <seealso cref="Text"/>
     public interface IKey : IValue
     {
-        [Pure]
-        byte? KeyPrefix { get; }
-
         [Pure]
         byte[] EncodeAsByteArray();
     }

--- a/Bencodex/Types/IKey.cs
+++ b/Bencodex/Types/IKey.cs
@@ -4,12 +4,12 @@ namespace Bencodex.Types
 {
     /// <summary>
     /// Represents Bencodex values which can be keys of a Bencodex <see cref="Dictionary"/>.
+    /// <para>It does not have extra ability over <see cref="IValue"/>, but just purposes to
+    /// group types can be keys of a Bencodex <see cref="Dictionary"/>.</para>
     /// </summary>
     /// <seealso cref="Binary"/>
     /// <seealso cref="Text"/>
     public interface IKey : IValue
     {
-        [Pure]
-        byte[] EncodeAsByteArray();
     }
 }

--- a/Bencodex/Types/IValue.cs
+++ b/Bencodex/Types/IValue.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
-using System.IO;
 
 namespace Bencodex.Types
 {
@@ -39,15 +38,6 @@ namespace Bencodex.Types
         /// method instead.</remarks>
         [Obsolete("Deprecated in favour of " + nameof(Inspect) + "() method.")]
         string Inspection { get; }
-
-        /// <summary>Encodes the value into <c cref="byte">Byte</c>
-        /// arrays.</summary>
-        /// <returns><c cref="byte">Byte</c> arrays of Bencodex
-        /// representation of the value.</returns>
-        /// <seealso cref="Codec.Encode(IValue)"/>
-        /// <seealso cref="Codec.Encode(IValue, System.IO.Stream)"/>
-        [Pure]
-        IEnumerable<byte[]> EncodeIntoChunks();
 
         /// <summary>
         /// Gets a human-readable representation for debugging.

--- a/Bencodex/Types/IValue.cs
+++ b/Bencodex/Types/IValue.cs
@@ -49,14 +49,6 @@ namespace Bencodex.Types
         [Pure]
         IEnumerable<byte[]> EncodeIntoChunks();
 
-        /// <summary>Writes the encoded value into <paramref name="stream"/>.
-        /// </summary>
-        /// <param name="stream">A stream to write the encoded value.</param>
-        /// <seealso cref="Codec.Encode(IValue)"/>
-        /// <seealso cref="Codec.Encode(IValue, System.IO.Stream)"/>
-        /// <seealso cref="EncodeIntoChunks"/>
-        void EncodeToStream(Stream stream);
-
         /// <summary>
         /// Gets a human-readable representation for debugging.
         /// <para>Unloaded values may be omitted.</para>
@@ -66,6 +58,6 @@ namespace Bencodex.Types
         /// <returns>A human-readable representation for debugging, which looks similar to Python's
         /// literal syntax.  However, if a value is a complex tree and contains any unloaded
         /// subvalues, these are omitted and their fingerprints are shown instead.</returns>
-        public string Inspect(bool loadAll);
+        string Inspect(bool loadAll);
     }
 }

--- a/Bencodex/Types/Integer.cs
+++ b/Bencodex/Types/Integer.cs
@@ -251,15 +251,6 @@ namespace Bencodex.Types
             yield return CommonVariables.Suffix;
         }
 
-        public void EncodeToStream(Stream stream)
-        {
-            stream.WriteByte(_prefix[0]);
-            string digits = Value.ToString(CultureInfo.InvariantCulture);
-            byte[] digitsAscii = Encoding.ASCII.GetBytes(digits);
-            stream.Write(digitsAscii, 0, digitsAscii.Length);
-            stream.WriteByte(CommonVariables.Suffix[0]);
-        }
-
         /// <inheritdoc cref="IValue.Inspect(bool)"/>
         public string Inspect(bool loadAll) =>
             Value.ToString(CultureInfo.InvariantCulture);

--- a/Bencodex/Types/Integer.cs
+++ b/Bencodex/Types/Integer.cs
@@ -2,10 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.Contracts;
 using System.Globalization;
-using System.IO;
 using System.Numerics;
 using System.Security.Cryptography;
-using System.Text;
 
 namespace Bencodex.Types
 {
@@ -17,8 +15,6 @@ namespace Bencodex.Types
         IComparable<Integer>,
         IComparable
     {
-        private static readonly byte[] _prefix = new byte[1] { 0x69 };  // 'i'
-
         public Integer(BigInteger value)
         {
             Value = value;
@@ -240,15 +236,6 @@ namespace Bencodex.Types
         public override int GetHashCode()
         {
             return Value.GetHashCode();
-        }
-
-        [Pure]
-        public IEnumerable<byte[]> EncodeIntoChunks()
-        {
-            yield return _prefix;
-            string digits = Value.ToString(CultureInfo.InvariantCulture);
-            yield return Encoding.ASCII.GetBytes(digits);
-            yield return CommonVariables.Suffix;
         }
 
         /// <inheritdoc cref="IValue.Inspect(bool)"/>

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -377,20 +377,6 @@ namespace Bencodex.Types
             _encodingLength = length;
         }
 
-        /// <inheritdoc cref="IValue.EncodeToStream(Stream)"/>
-        public void EncodeToStream(Stream stream)
-        {
-            long startPos = stream.Position;
-            stream.WriteByte(_listPrefix[0]);
-            foreach (IValue element in this)
-            {
-                element.EncodeToStream(stream);
-            }
-
-            stream.WriteByte(CommonVariables.Suffix[0]);
-            _encodingLength = (int?)((int)stream.Position - startPos);
-        }
-
         /// <inheritdoc cref="IValue.Inspect(bool)"/>
         public string Inspect(bool loadAll)
         {

--- a/Bencodex/Types/Null.cs
+++ b/Bencodex/Types/Null.cs
@@ -65,11 +65,6 @@ namespace Bencodex.Types
             yield return new byte[1] { 0x6e }; // 'n'
         }
 
-        public void EncodeToStream(Stream stream)
-        {
-            stream.WriteByte(0x6e); // 'n'
-        }
-
         /// <inheritdoc cref="IValue.Inspect(bool)"/>
         public string Inspect(bool loadAll) => "null";
 

--- a/Bencodex/Types/Null.cs
+++ b/Bencodex/Types/Null.cs
@@ -1,7 +1,5 @@
 using System;
-using System.Collections.Generic;
 using System.Diagnostics.Contracts;
-using System.IO;
 
 namespace Bencodex.Types
 {
@@ -58,12 +56,6 @@ namespace Bencodex.Types
             other is Null;
 
         bool IEquatable<Null>.Equals(Null other) => true;
-
-        [Pure]
-        public IEnumerable<byte[]> EncodeIntoChunks()
-        {
-            yield return new byte[1] { 0x6e }; // 'n'
-        }
 
         /// <inheritdoc cref="IValue.Inspect(bool)"/>
         public string Inspect(bool loadAll) => "null";

--- a/Bencodex/Types/Text.cs
+++ b/Bencodex/Types/Text.cs
@@ -159,9 +159,6 @@ namespace Bencodex.Types
             }
         }
 
-        [Pure]
-        byte[] IKey.EncodeAsByteArray() => Encoding.UTF8.GetBytes(Value);
-
         /// <inheritdoc cref="IValue.Inspect(bool)"/>
         public string Inspect(bool loadAll)
         {

--- a/Bencodex/Types/Text.cs
+++ b/Bencodex/Types/Text.cs
@@ -184,19 +184,6 @@ namespace Bencodex.Types
             yield return utf8;
         }
 
-        public void EncodeToStream(Stream stream)
-        {
-            stream.WriteByte(_keyPrefix);
-            string len = Utf8Length.ToString(CultureInfo.InvariantCulture);
-            byte[] lenBytes = Encoding.ASCII.GetBytes(len);
-            stream.Write(lenBytes, 0, lenBytes.Length);
-            stream.WriteByte(CommonVariables.Separator[0]);
-
-            // FIXME: Is the buffer for the entire string necessary?
-            byte[] utf8 = ((IKey)this).EncodeAsByteArray();
-            stream.Write(utf8, 0, utf8.Length);
-        }
-
         /// <inheritdoc cref="IValue.Inspect(bool)"/>
         public string Inspect(bool loadAll)
         {

--- a/Bencodex/Types/Text.cs
+++ b/Bencodex/Types/Text.cs
@@ -1,9 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.Contracts;
 using System.Globalization;
-using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -17,10 +15,6 @@ namespace Bencodex.Types
         IEquatable<string>,
         IComparable
     {
-        private const byte _keyPrefix = 0x75;
-
-        private static readonly byte[] _keyPrefixByteArray = new byte[1] { _keyPrefix };
-
         private int? _utf8Length;
         private ImmutableArray<byte>? _digest;
         private string? _value;
@@ -167,19 +161,6 @@ namespace Bencodex.Types
 
         [Pure]
         byte[] IKey.EncodeAsByteArray() => Encoding.UTF8.GetBytes(Value);
-
-        [Pure]
-        public IEnumerable<byte[]> EncodeIntoChunks()
-        {
-            yield return _keyPrefixByteArray;
-            string len = Utf8Length.ToString(CultureInfo.InvariantCulture);
-            yield return Encoding.ASCII.GetBytes(len);
-            yield return CommonVariables.Separator;
-
-            // FIXME: Is the buffer for the entire string necessary?
-            byte[] utf8 = ((IKey)this).EncodeAsByteArray();
-            yield return utf8;
-        }
 
         /// <inheritdoc cref="IValue.Inspect(bool)"/>
         public string Inspect(bool loadAll)

--- a/Bencodex/Types/Text.cs
+++ b/Bencodex/Types/Text.cs
@@ -34,9 +34,6 @@ namespace Bencodex.Types
 
         public string Value => _value ?? (_value = string.Empty);
 
-        [Pure]
-        byte? IKey.KeyPrefix => _keyPrefix;  // 'u'
-
         /// <inheritdoc cref="IValue.Kind"/>
         [Pure]
         public ValueKind Kind => ValueKind.Text;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,7 @@ To be released.
  -  `Dictionary.Empty` static property became a static readonly field.  [[#50]]
  -  Deprecated `IValue.Inspection` property in favor of `IValue.Inspect(bool)`
     method.  [[#52]]
+ -  Removed `IValue.EncodeToStream()` method. [[#54]]
  -  Removed `Bencodex.Types.List.Value` property.  [[#52]]
  -  Removed `Bencodex.Types.CommonVariables` static class.  [[#50]]
 
@@ -56,6 +57,7 @@ To be released.
 [#51]: https://github.com/planetarium/bencodex.net/pull/51
 [#52]: https://github.com/planetarium/bencodex.net/pull/52
 [#53]: https://github.com/planetarium/bencodex.net/pull/53
+[#54]: https://github.com/planetarium/bencodex.net/pull/54
 
 
 Version 0.3.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@ To be released.
  -  Deprecated `IValue.Inspection` property in favor of `IValue.Inspect(bool)`
     method.  [[#52]]
  -  Removed `IValue.EncodeToStream()` method. [[#54]]
+ -  Removed `IKey.KeyPrefix` property.  [[#54]]
  -  Removed `Bencodex.Types.List.Value` property.  [[#52]]
  -  Removed `Bencodex.Types.CommonVariables` static class.  [[#50]]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,7 @@ To be released.
     method.  [[#52]]
  -  Removed `IValue.EncodeToStream()` method. [[#54]]
  -  Removed `IValue.EncodeIntoChunks()` method. [[#54]]
+ -  Removed `IKey.EncodeAsByteArray()` method.  [[#54]]
  -  Removed `IKey.KeyPrefix` property.  [[#54]]
  -  Removed `Bencodex.Types.List.Value` property.  [[#52]]
  -  Removed `Bencodex.Types.CommonVariables` static class.  [[#50]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,6 +49,7 @@ To be released.
  -  Deprecated `IValue.Inspection` property in favor of `IValue.Inspect(bool)`
     method.  [[#52]]
  -  Removed `IValue.EncodeToStream()` method. [[#54]]
+ -  Removed `IValue.EncodeIntoChunks()` method. [[#54]]
  -  Removed `IKey.KeyPrefix` property.  [[#54]]
  -  Removed `Bencodex.Types.List.Value` property.  [[#52]]
  -  Removed `Bencodex.Types.CommonVariables` static class.  [[#50]]


### PR DESCRIPTION
This patch fixes a regression made by <https://github.com/planetarium/bencodex.net/pull/49> that `Codec.Encode(IValue, Stream)` requires a stream to be seekable.  Now it accepts any readable streams again.

During this fix, I rewrote the whole encoding logic (so that it does not require streams to be seekable), and accidentally it became drastically faster than before.  Below strategies were applied:

- Instead of a lot of memory allocations for small chunks, it allocates the single long buffer with the exact length of the required bytes for the entire encoded representation.
- When it writes onto a stream, smaller chunks shorter than 4,096 bytes are grouped into a single chunk.
- Unnecessary memcpys were reduced using C#'s `in` keyword for parameters.
- Encoding methods became static in order to avoid dynamic dispatch.

Here's some benchmarks too.  The encoded `Dictionary` weighs about 11 MB.  Benchmarks ran on my MacBook Pro.[^1]

Before optimization (d5cb15bf31b28efe52ee3ce0ec62c6625bf4f7e6):

|           Method |             DataFile |     Mean |    Error |   StdDev |
|----------------- |--------------------- |---------:|---------:|---------:|
|  EncodeIntoBytes | /tmp/(...)e.dat [82] | 32.97 ms | 15.42 ms | 0.845 ms |
| EncodeIntoStream | /tmp/(...)e.dat [82] | 27.24 ms | 19.05 ms | 1.044 ms |

After optimization (a98b62a0d4019f0b2a2cfee7d5c71e8d196c65af):

|           Method |             DataFile |         Mean |        Error |    StdDev |
|----------------- |--------------------- |-------------:|-------------:|----------:|
|  EncodeIntoBytes | /tmp/(...)e.dat [96] |  8,402.07 us | 16,322.05 us | 894.67 us |
| EncodeIntoStream | /tmp/(...)e.dat [96] |     26.45 us |    211.34 us |  11.58 us |

To sum up:

- `Codec.Encode(IValue)` is about 4 times faster than before.
- `Codec.Encdoe(IValue, Stream)` is about 1,000 times faster than before.

[^1]: Intel Core i7 2.2GHz. 16GB 2400MHz DDR4. macOS 11.6. .NET Core SDK 3.1.411.