### PR TITLE
Codec with offload options

### DIFF
--- a/Bencodex.Tests/CodecTest.cs
+++ b/Bencodex.Tests/CodecTest.cs
@@ -1,16 +1,27 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Text;
 using Bencodex.Types;
 using Xunit;
 using Xunit.Abstractions;
+using static Bencodex.Tests.TestUtils;
 
 namespace Bencodex.Tests
 {
     public class CodecTest
     {
         private readonly ITestOutputHelper _output;
+        private readonly Encoding _utf8;
 
         public CodecTest(ITestOutputHelper output)
         {
             _output = output;
+            _utf8 = Encoding.GetEncoding(
+                "UTF-8",
+                new EncoderReplacementFallback(),
+                new DecoderReplacementFallback()
+            );
         }
 
         [Theory]
@@ -21,10 +32,39 @@ namespace Bencodex.Tests
             _output.WriteLine("Data: {0}", spec.EncodingPath);
             Codec codec = new Codec();
             IValue decoded = codec.Decode(spec.Encoding);
+            _output.WriteLine("Value: {0}", decoded.Inspect(false));
             Assert.Equal(spec.Semantics, decoded);
             Assert.Equal(spec.Encoding.LongLength, decoded.EncodingLength);
             Assert.Equal(spec.Semantics.EncodingLength, decoded.EncodingLength);
             Assert.Equal(spec.Semantics.Fingerprint, decoded.Fingerprint);
+
+            byte[] encoded = codec.Encode(spec.Semantics);
+            AssertEqual(spec.Encoding, encoded);
+
+            var random = new Random();
+            var toOffload = new ConcurrentDictionary<Fingerprint, bool>();
+            var offloaded = new ConcurrentDictionary<Fingerprint, IValue>();
+            var offloadOptions = new OffloadOptions(
+                iv => toOffload.TryGetValue(iv.Fingerprint, out bool v)
+                    ? v
+                    : toOffload[iv.Fingerprint] = random.Next() % 2 == 0,
+                (iv, loader) => offloaded[iv.Fingerprint] = iv.GetValue(loader)
+            );
+            byte[] encodingWithOffload = codec.Encode(spec.Semantics, offloadOptions);
+            _output.WriteLine(
+                "Encoding with offload ({0}): {1}",
+                encodingWithOffload.LongLength,
+                _utf8.GetString(encodingWithOffload)
+            );
+            _output.WriteLine(
+                "Encoding with offload (hex): {0}",
+                BitConverter.ToString(encodingWithOffload)
+            );
+            _output.WriteLine("Offloaded values:");
+            foreach (KeyValuePair<Fingerprint, IValue> pair in offloaded)
+            {
+                _output.WriteLine("- {0}", pair.Key);
+            }
         }
     }
 }

--- a/Bencodex.Tests/CodecTest.cs
+++ b/Bencodex.Tests/CodecTest.cs
@@ -65,6 +65,14 @@ namespace Bencodex.Tests
             {
                 _output.WriteLine("- {0}", pair.Key);
             }
+
+            IValue partiallyDecoded = codec.Decode(
+                encodingWithOffload,
+                fp => offloaded[fp]
+            );
+            Assert.Equal(spec.Semantics.Fingerprint, partiallyDecoded.Fingerprint);
+            Assert.Equal(spec.Semantics, partiallyDecoded);
+            Assert.Equal(spec.Semantics.Inspect(true), partiallyDecoded.Inspect(true));
         }
     }
 }

--- a/Bencodex.Tests/EncoderTest.cs
+++ b/Bencodex.Tests/EncoderTest.cs
@@ -106,6 +106,17 @@ namespace Bencodex.Tests
                 0x65,  // 'e'
             };
             AssertEqual(expectedEncoding, encoded);
+            var decoder = new Decoder(
+                new MemoryStream(encoded),
+                f =>
+                    new IValue[]
+                    {
+                        longText,
+                        subList,
+                        anotherLongText,
+                    }.First(v => v.Fingerprint.Equals(f))
+            );
+            Assert.Equal(list, decoder.Decode());
         }
 
         [Fact]

--- a/Bencodex.Tests/EncoderTest.cs
+++ b/Bencodex.Tests/EncoderTest.cs
@@ -1,0 +1,243 @@
+﻿using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Bencodex.Types;
+using Xunit;
+using static System.Array;
+using static Bencodex.Tests.TestUtils;
+using Boolean = Bencodex.Types.Boolean;
+
+namespace Bencodex.Tests
+{
+    public class EncoderTest
+    {
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
+        public void EstimateLength(bool offload)
+        {
+            int offloaded = 0;
+            IOffloadOptions offloadOptions = offload
+                ? new OffloadOptions(_ => false, (i, l) => offloaded++)
+                : null;
+            Assert.Equal(1, Encoder.EstimateLength(Null.Value, offloadOptions));
+            Assert.Equal(1, Encoder.EstimateLength(new Boolean(true), offloadOptions));
+            Assert.Equal(5, Encoder.EstimateLength(new Integer(123), offloadOptions));
+            Assert.Equal(
+                14,
+                Encoder.EstimateLength(new Binary("hello world", Encoding.ASCII), offloadOptions)
+            );
+            Assert.Equal(15, Encoder.EstimateLength(new Text("hello world"), offloadOptions));
+            Assert.Equal(0, offloaded);
+        }
+
+        [Fact]
+        public void Offload()
+        {
+            var offloaded = new HashSet<Fingerprint>();
+            var offloadOptions = new OffloadOptions(
+                embedPredicate: i => i.EncodingLength < 10L || i.Kind == ValueKind.Dictionary,
+                offloadAction: (i, _) => offloaded.Add(i.Fingerprint)
+            );
+            var longText = new Text("hello world");
+            var subList = new List(Null.Value, new Boolean(false), new Text("foobar"));
+            var anotherLongText = new Text("another long text");
+            var list = new List(
+                Null.Value,
+                new Boolean(true),
+                new Integer(12345),
+                new Binary("foo", Encoding.ASCII),
+                longText,
+                subList,
+                new Dictionary(new[]
+                {
+                    new KeyValuePair<IKey, IValue>(new Text("foo"), Null.Value),
+                    new KeyValuePair<IKey, IValue>(new Text("bar"), anotherLongText),
+                })
+            );
+            Assert.Equal(list.EncodingLength, Encoder.EstimateLength(list, null));
+            Assert.Empty(offloaded);
+            Assert.Equal(118L, Encoder.EstimateLength(list, offloadOptions));
+            Assert.Empty(offloaded);
+            byte[] encoded = Encoder.Encode(list, offloadOptions);
+            Assert.Equal(118L, encoded.Length);
+            Assert.Equal(
+                new HashSet<Fingerprint>()
+                {
+                    longText.Fingerprint,
+                    subList.Fingerprint,
+                    anotherLongText.Fingerprint,
+                },
+                offloaded
+            );
+            byte[] expectedEncoding =
+            {
+                0x6c,  // 'l'
+
+                0x6e,  // 'n'
+                0x74,  // 't'
+                0x69, 0x31, 0x32, 0x33, 0x34, 0x35, 0x65,  // "i12345e"
+                0x33, 0x3a, 0x66, 0x6f, 0x6f,  // "3:foo"
+
+                0x2a, 0x32, 0x30, 0x3a,  // "*20:"
+                4, // ValueKind.Text = 4
+                0, 0, 0, 0, 0, 0, 0, 15, // [64-bit int big endian] 15
+                0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20, 0x77, 0x6f, 0x72, 0x6c, 0x64,  // "hello world"
+
+                0x2a, 0x32, 0x39, 0x3a,  // "*29:"
+                5,  // ValueKind.List = 5
+                0, 0, 0, 0, 0, 0, 0, 13,  // [64-bit int big endian] 13
+                0x6e, 0x34, 0x7e, 0xb8, 0xa1, 0xfd, 0x7e, 0xd7, 0xfb, 0xad,  // SHA 1 (upper)
+                0xee, 0x1d, 0x04, 0x4f, 0xef, 0x42, 0x51, 0x61, 0x2a, 0x93,  // SHA 1 (lower)
+
+                0x64,  // 'd'
+                0x75, 0x33, 0x3a, 0x62, 0x61, 0x72,  // 'u3:bar'
+                0x2a, 0x32, 0x36, 0x3a,  // "*26:"
+                4, // ValueKind.Text = 4
+                0, 0, 0, 0, 0, 0, 0, 21, // [64-bit int big endian] 21
+                0x61, 0x6e, 0x6f, 0x74, 0x68, 0x65, 0x72, 0x20,  // "another "
+                0x6c, 0x6f, 0x6e, 0x67, 0x20, 0x74, 0x65, 0x78, 0x74,  // "long text"
+                0x75, 0x33, 0x3a, 0x66, 0x6f, 0x6f,  // "u3:foo"
+                0x6e,  // 'n'
+                0x65,  // 'e'
+
+                0x65,  // 'e'
+            };
+            AssertEqual(expectedEncoding, encoded);
+        }
+
+        [Fact]
+        public void EncodeNull()
+        {
+            var buffer = new byte[10];
+            long size = Encoder.EncodeNull(buffer, 3L);
+            Assert.Equal(1L, size);
+            AssertEqual(new byte[] { 0, 0, 0, 0x6e, 0, 0, 0, 0, 0, 0 }, buffer);
+        }
+
+        [Fact]
+        public void EncodeBoolean()
+        {
+            var buffer = new byte[10];
+            long size = Encoder.EncodeBoolean(new Boolean(true), buffer, 2L);
+            Assert.Equal(1L, size);
+            AssertEqual(new byte[] { 0, 0, 0x74, 0, 0, 0, 0, 0, 0, 0 }, buffer);
+
+            size = Encoder.EncodeBoolean(new Boolean(false), buffer, 5L);
+            Assert.Equal(1L, size);
+            AssertEqual(new byte[] { 0, 0, 0x74, 0, 0, 0x66, 0, 0, 0, 0 }, buffer);
+        }
+
+        [Fact]
+        public void EncodeInteger()
+        {
+            var buffer = new byte[10];
+            long size = Encoder.EncodeInteger(0, buffer, 2L);
+            Assert.Equal(3L, size);
+            AssertEqual(new byte[] { 0, 0, 0x69, 0x30, 0x65, 0, 0, 0, 0, 0 }, buffer);
+
+            Clear(buffer, 0, buffer.Length);
+            size = Encoder.EncodeInteger(-123, buffer, 1L);
+            Assert.Equal(6L, size);
+            AssertEqual(new byte[] { 0, 0x69, 0x2d, 0x31, 0x32, 0x33, 0x65, 0, 0, 0 }, buffer);
+
+            Clear(buffer, 0, buffer.Length);
+            size = Encoder.EncodeInteger(456, buffer, 4L);
+            Assert.Equal(5L, size);
+            AssertEqual(new byte[] { 0, 0, 0, 0, 0x69, 0x34, 0x35, 0x36, 0x65, 0 }, buffer);
+        }
+
+        [Fact]
+        public void EncodeBinary()
+        {
+            var buffer = new byte[20];
+            long size = Encoder.EncodeBinary(new Binary("hello world", Encoding.ASCII), buffer, 2L);
+            Assert.Equal(14L, size);
+            AssertEqual(
+                new byte[20]
+                {
+                    0, 0,
+                    0x31, 0x31, 0x3a,  // "11:"
+                    0x68, 0x65, 0x6c, 0x6c, 0x6f, 0x20,  // "hello "
+                    0x77, 0x6f, 0x72, 0x6c, 0x64, // "world"
+                    0, 0, 0, 0,
+                },
+                buffer
+            );
+        }
+
+        [Fact]
+        public void EncodeText()
+        {
+            var buffer = new byte[20];
+            long size = Encoder.EncodeText("한글", buffer, 5L);
+            Assert.Equal(9L, size);
+            AssertEqual(
+                new byte[20]
+                {
+                    0, 0, 0, 0, 0,
+                    0x75, 0x36, 0x3a,  // "u6:"
+                    0xed, 0x95, 0x9c, 0xea, 0xb8, 0x80,  // "한글"
+                    0, 0, 0, 0, 0, 0,
+                },
+                buffer
+            );
+        }
+
+        [Fact]
+        public void CountDecimalDigits()
+        {
+            for (long i = 0; i <= 1000L; i++)
+            {
+                Assert.Equal(
+                    i.ToString(CultureInfo.InvariantCulture).Length,
+                    Encoder.CountDecimalDigits(i)
+                );
+            }
+
+            var random = new System.Random();
+            for (int i = 0; i < 100; i++)
+            {
+                long n = (long)random.Next(0, int.MaxValue);
+                Assert.Equal(
+                    n.ToString(CultureInfo.InvariantCulture).Length,
+                    Encoder.CountDecimalDigits(n)
+                );
+            }
+        }
+
+        [Fact]
+        public void EncodeDigits()
+        {
+            var buffer = new byte[10];
+            long size = Encoder.EncodeDigits(0L, buffer, 2L);
+            Assert.Equal(1L, size);
+            AssertEqual(new byte[] { 0, 0, 0x30, 0, 0, 0, 0, 0, 0, 0 }, buffer);
+
+            Clear(buffer, 0, buffer.Length);
+            size = Encoder.EncodeDigits(5L, buffer, 0L);
+            Assert.Equal(1L, size);
+            AssertEqual(new byte[] { 0x35, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, buffer);
+
+            Clear(buffer, 0, buffer.Length);
+            size = Encoder.EncodeDigits(10L, buffer, 5L);
+            Assert.Equal(2L, size);
+            AssertEqual(new byte[] { 0, 0, 0, 0, 0, 0x31, 0x30, 0, 0, 0 }, buffer);
+
+            Clear(buffer, 0, buffer.Length);
+            size = Encoder.EncodeDigits(123L, buffer, 6L);
+            Assert.Equal(3L, size);
+            AssertEqual(new byte[] { 0, 0, 0, 0, 0, 0, 0x31, 0x32, 0x33, 0 }, buffer);
+
+            Clear(buffer, 0, buffer.Length);
+            size = Encoder.EncodeDigits(9876543210L, buffer, 0L);
+            Assert.Equal(10L, size);
+            AssertEqual(
+                new byte[] { 0x39, 0x38, 0x37, 0x36, 0x35, 0x34, 0x33, 0x32, 0x31, 0x30 },
+                buffer
+            );
+        }
+    }
+}

--- a/Bencodex.Tests/TestUtils.cs
+++ b/Bencodex.Tests/TestUtils.cs
@@ -21,13 +21,15 @@ namespace Bencodex.Tests
             Assert.True(
                 expected.SequenceEqual(actual),
                 string.Format(
-                    "{4}{5}" +
-                    "Expected: {0}\nActual:   {1}\n" +
+                    "{6}{7}" +
+                    "Expected ({4}): {0}\nActual ({5}):   {1}\n" +
                     "Expected (hex): {2}\nActual (hex):   {3}",
                     utf8.GetString(expected),
                     utf8.GetString(actual),
                     BitConverter.ToString(expected),
                     BitConverter.ToString(actual),
+                    expected.LongLength,
+                    actual.LongLength,
                     message ?? string.Empty,
                     message == null ? string.Empty : "\n"
                 )

--- a/Bencodex.Tests/Types/IndirectValueTest.cs
+++ b/Bencodex.Tests/Types/IndirectValueTest.cs
@@ -73,10 +73,10 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void Kind()
         {
-            Assert.Equal(ValueKind.List, _loaded.Type);
-            Assert.Equal(ValueKind.Dictionary, _unloaded.Type);
+            Assert.Equal(ValueKind.List, _loaded.Kind);
+            Assert.Equal(ValueKind.Dictionary, _unloaded.Kind);
             Assert.Null(_unloaded.LoadedValue);
-            Assert.Throws<InvalidOperationException>(() => _default.Type);
+            Assert.Throws<InvalidOperationException>(() => _default.Kind);
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/IntegerTest.cs
+++ b/Bencodex.Tests/Types/IntegerTest.cs
@@ -92,6 +92,28 @@ namespace Bencodex.Tests.Types
             Assert.Equal("Bencodex.Types.Integer -456", new Integer(-456).ToString());
         }
 
+        [Fact]
+        public void CountDecimalDigits()
+        {
+            for (int i = -1000; i <= 1000; i++)
+            {
+                Assert.Equal(
+                    i.ToString(CultureInfo.InvariantCulture).Length,
+                    new Integer(i).CountDecimalDigits()
+                );
+            }
+
+            var random = new Random();
+            for (int i = 0; i < 100; i++)
+            {
+                int n = random.Next(int.MinValue, int.MaxValue);
+                Assert.Equal(
+                    n.ToString(CultureInfo.InvariantCulture).Length,
+                    new Integer(n).CountDecimalDigits()
+                );
+            }
+        }
+
         private void IntegerGeneric(Func<int, Integer?> convert)
         {
             Codec codec = new Codec();

--- a/Bencodex/AssemblyInfo.cs
+++ b/Bencodex/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Bencodex.Tests")]

--- a/Bencodex/Codec.cs
+++ b/Bencodex/Codec.cs
@@ -12,6 +12,29 @@ namespace Bencodex
     public class Codec
     {
         /// <summary>
+        /// Encodes a <paramref name="value"/> into a single <see cref="byte"/> array, rather than
+        /// split into multiple chunks.</summary>
+        /// <param name="value">A value to encode.</param>
+        /// <param name="offloadOptions">Optionally configures how to offload heavy values included
+        /// in lists and dictionaries.</param>
+        /// <returns>A single <see cref="byte"/> array which contains the whole Bencodex
+        /// representation of the <paramref name="value"/>.</returns>
+        [Pure]
+        public byte[] Encode(IValue value, IOffloadOptions? offloadOptions) =>
+            Encoder.Encode(value, offloadOptions);
+
+        /// <summary>Encodes a <paramref name="value"/>, and writes it on
+        /// the <paramref name="output"/> stream.</summary>
+        /// <param name="value">A value to encode.</param>
+        /// <param name="output">A stream that a value is printed on.</param>
+        /// <param name="offloadOptions">Optionally configures how to offload heavy values included
+        /// in lists and dictionaries.</param>
+        /// <exception cref="ArgumentException">Thrown when the given <paramref name="output"/>
+        /// stream is not writable.</exception>
+        public void Encode(IValue value, Stream output, IOffloadOptions? offloadOptions) =>
+            Encoder.Encode(value, output, offloadOptions);
+
+        /// <summary>
         /// Encodes a <paramref name="value"/> into a single
         /// <c cref="byte">Byte</c> array, rather than split into
         /// multiple chunks.</summary>
@@ -20,7 +43,7 @@ namespace Bencodex
         /// contains the whole Bencodex representation of
         /// the <paramref name="value"/>.</returns>
         [Pure]
-        public byte[] Encode(IValue value) => Encoder.Encode(value);
+        public byte[] Encode(IValue value) => Encoder.Encode(value, offloadOptions: null);
 
         /// <summary>Encodes a <paramref name="value"/>,
         /// and write it on an <paramref name="output"/> stream.</summary>
@@ -28,7 +51,8 @@ namespace Bencodex
         /// <param name="output">A stream that a value is printed on.</param>
         /// <exception cref="ArgumentException">Thrown when a given
         /// <paramref name="output"/> stream is not writable.</exception>
-        public void Encode(IValue value, Stream output) => Encoder.Encode(value, output);
+        public void Encode(IValue value, Stream output) =>
+            Encode(value, output, offloadOptions: null);
 
         /// <summary>Decodes an encoded value from an <paramref name="input"/>
         /// stream.</summary>

--- a/Bencodex/Codec.cs
+++ b/Bencodex/Codec.cs
@@ -54,6 +54,38 @@ namespace Bencodex
         public void Encode(IValue value, Stream output) =>
             Encode(value, output, offloadOptions: null);
 
+        /// <summary>Decodes an encoded value with extended format for offloaded values from
+        /// an <paramref name="input"/> stream.</summary>
+        /// <param name="input">An input stream to decode.</param>
+        /// <param name="indirectValueLoader">An optional <see cref="IndirectValue.Loader"/>
+        /// delegate invoked when offloaded values are needed.</param>
+        /// <returns>A decoded value.</returns>
+        /// <exception cref="ArgumentException">Thrown when a given
+        /// <paramref name="input"/> stream is not readable.</exception>
+        /// <exception cref="DecodingException">Thrown when a binary representation of
+        /// an <paramref name="input"/> stream is not a valid Bencodex encoding.</exception>
+        public IValue Decode(Stream input, IndirectValue.Loader? indirectValueLoader)
+        {
+            if (!input.CanRead)
+            {
+                throw new ArgumentException("The input stream cannot be read.", nameof(input));
+            }
+
+            return new Decoder(input, indirectValueLoader).Decode();
+        }
+
+        /// <summary>Decodes an encoded value with extended format for offloaded values from
+        /// a <see cref="byte"/> array.</summary>
+        /// <param name="bytes">A <see cref="byte"/> array of Bencodex encoding.</param>
+        /// <param name="indirectValueLoader">An optional <see cref="IndirectValue.Loader"/>
+        /// delegate invoked when offloaded values are needed.</param>
+        /// <returns>A decoded value.</returns>
+        /// <exception cref="DecodingException">Thrown when a <paramref name="bytes"/>
+        /// representation is not a valid Bencodex encoding.</exception>
+        [Pure]
+        public IValue Decode(byte[] bytes, IndirectValue.Loader? indirectValueLoader) =>
+            Decode(new MemoryStream(bytes, false), indirectValueLoader);
+
         /// <summary>Decodes an encoded value from an <paramref name="input"/>
         /// stream.</summary>
         /// <param name="input">An input stream to decode.</param>
@@ -63,18 +95,7 @@ namespace Bencodex
         /// <exception cref="DecodingException">Thrown when a binary
         /// representation of an <paramref name="input"/> stream is not a valid
         /// Bencodex encoding.</exception>
-        public IValue Decode(Stream input)
-        {
-            if (!input.CanRead)
-            {
-                throw new ArgumentException(
-                    "stream cannot be read",
-                    nameof(input)
-                );
-            }
-
-            return new Decoder(input).Decode();
-        }
+        public IValue Decode(Stream input) => Decode(input, indirectValueLoader: null);
 
         /// <summary>Decodes an encoded value from a
         /// <c cref="byte">Byte</c> array.</summary>
@@ -85,9 +106,6 @@ namespace Bencodex
         /// <paramref name="bytes"/> representation is not a valid Bencodex
         /// encoding.</exception>
         [Pure]
-        public IValue Decode(byte[] bytes)
-        {
-            return Decode(new MemoryStream(bytes, false));
-        }
+        public IValue Decode(byte[] bytes) => Decode(bytes, indirectValueLoader: null);
     }
 }

--- a/Bencodex/Encoder.cs
+++ b/Bencodex/Encoder.cs
@@ -9,14 +9,17 @@ namespace Bencodex
 {
     internal static class Encoder
     {
-        public static byte[] Encode(IValue value)
+        // TODO: Needs a unit test.
+        public static byte[] Encode(IValue value, IOffloadOptions? offloadOptions)
         {
-            var buffer = new byte[value.EncodingLength];
-            Encode(value, buffer, 0L);
+            long estimatedLength = EstimateLength(value, offloadOptions);
+            var buffer = new byte[estimatedLength];
+            Encode(value, offloadOptions, buffer, 0L);
             return buffer;
         }
 
-        public static void Encode(IValue value, Stream output)
+        // TODO: Needs a unit test.
+        public static void Encode(IValue value, Stream output, IOffloadOptions? offloadOptions)
         {
             if (!output.CanWrite)
             {
@@ -26,7 +29,8 @@ namespace Bencodex
                 );
             }
 
-            if (value.EncodingLength > 4096L)
+            long estimatedLength = EstimateLength(value, offloadOptions);
+            if (estimatedLength > 4096L)
             {
                 switch (value)
                 {
@@ -34,7 +38,7 @@ namespace Bencodex
                         output.WriteByte(0x6c);  // 'l'
                         foreach (IValue el in l)
                         {
-                            Encode(el, output);
+                            Encode(el, output, offloadOptions);
                         }
 
                         output.WriteByte(0x65);  // 'e'
@@ -44,8 +48,8 @@ namespace Bencodex
                         output.WriteByte(0x6c);  // 'l'
                         foreach (KeyValuePair<IKey, IValue> pair in d)
                         {
-                            Encode(pair.Key, output);
-                            Encode(pair.Value, output);
+                            Encode(pair.Key, output, offloadOptions);
+                            Encode(pair.Value, output, offloadOptions);
                         }
 
                         output.WriteByte(0x65);  // 'e'
@@ -55,17 +59,65 @@ namespace Bencodex
                 return;
             }
 
-            byte[] buffer = Encode(value);
+            byte[] buffer = Encode(value, offloadOptions);
             output.Write(buffer, 0, buffer.Length);
         }
 
-        private static long EncodeNull(in Null value, byte[] buffer, long offset)
+        internal static long EstimateLength(IValue value, IOffloadOptions? offloadOptions)
+        {
+            if (!(offloadOptions is { } oo))
+            {
+                return value.EncodingLength;
+            }
+            else if (value is List list)
+            {
+                long listLen = 2L;
+                foreach (IndirectValue iv in list.EnumerateIndirectValues())
+                {
+                    if (oo.Embeds(iv))
+                    {
+                        listLen += EstimateLength(iv.GetValue(list.Loader), oo);
+                    }
+                    else
+                    {
+                        long fpLen = iv.Fingerprint.CountSerializationBytes();
+                        listLen += 2L + CountDecimalDigits(fpLen) + fpLen;
+                    }
+                }
+
+                return listLen;
+            }
+            else if (value is Dictionary dict)
+            {
+                long dictLen = 2L;
+                foreach (KeyValuePair<IKey, IndirectValue> pair in dict.EnumerateIndirectValues())
+                {
+                    dictLen += pair.Key.EncodingLength;
+                    IndirectValue iv = pair.Value;
+                    if (oo.Embeds(iv))
+                    {
+                        dictLen += EstimateLength(iv.GetValue(dict.Loader), oo);
+                    }
+                    else
+                    {
+                        long fpLen = iv.Fingerprint.CountSerializationBytes();
+                        dictLen += 2L + CountDecimalDigits(fpLen) + fpLen;
+                    }
+                }
+
+                return dictLen;
+            }
+
+            return value.EncodingLength;
+        }
+
+        internal static long EncodeNull(byte[] buffer, long offset)
         {
             buffer[offset] = 0x6e;  // 'n'
             return 1L;
         }
 
-        private static long EncodeBoolean(in Types.Boolean value, byte[] buffer, long offset)
+        internal static long EncodeBoolean(in Types.Boolean value, byte[] buffer, long offset)
         {
             buffer[offset] = value.Value
                 ? (byte)0x74 // 't'
@@ -73,16 +125,11 @@ namespace Bencodex
             return 1L;
         }
 
-        private static long EncodeInteger(in Integer value, byte[] buffer, long offset)
+        internal static long EncodeInteger(in Integer value, byte[] buffer, long offset)
         {
             buffer[offset] = 0x69;  // 'i'
             offset++;
             string digits = value.Value.ToString(CultureInfo.InvariantCulture);
-            if (buffer.LongLength < offset + digits.Length + 1L)
-            {
-                throw new IndexOutOfRangeException("The " + nameof(buffer) + " is not enough.");
-            }
-
             if (offset + digits.Length <= int.MaxValue)
             {
                 Encoding.ASCII.GetBytes(digits, 0, digits.Length, buffer, (int)offset);
@@ -98,22 +145,10 @@ namespace Bencodex
             return 1L + digits.Length + 1L;
         }
 
-        private static long EncodeBinary(in Binary value, byte[] buffer, long offset)
+        internal static long EncodeBinary(in Binary value, byte[] buffer, long offset)
         {
-            int len = value.ByteArray.Length;
-            string lenStr = len.ToString(CultureInfo.InvariantCulture);
-            long lenStrLength = lenStr.Length;
-            if (offset + lenStrLength <= int.MaxValue)
-            {
-                lenStrLength = Encoding.ASCII.GetBytes(lenStr, 0, lenStr.Length, buffer, (int)offset);
-            }
-            else
-            {
-                byte[] lenStrBytes = Encoding.ASCII.GetBytes(lenStr);
-                lenStrLength = lenStrBytes.LongLength;
-                Array.Copy(lenStrBytes, 0L, buffer, offset, lenStrLength);
-            }
-
+            long len = value.ByteArray.Length;
+            long lenStrLength = EncodeDigits(len, buffer, offset);
             offset += lenStrLength;
             buffer[offset] = 0x3a;  // ':'
             offset++;
@@ -129,23 +164,11 @@ namespace Bencodex
             return lenStrLength + 1L + b.LongLength;
         }
 
-        private static long EncodeText(in Text value, byte[] buffer, long offset)
+        internal static long EncodeText(in Text value, byte[] buffer, long offset)
         {
             buffer[offset++] = 0x75;  // 'u'
             int utf8Length = value.Utf8Length;
-            string lenStr = utf8Length.ToString(CultureInfo.InvariantCulture);
-            long lenStrLength = lenStr.Length;
-            if (offset + lenStr.Length <= int.MaxValue)
-            {
-                lenStrLength = Encoding.ASCII.GetBytes(lenStr, 0, lenStr.Length, buffer, (int)offset);
-            }
-            else
-            {
-                byte[] lenStrBytes = Encoding.ASCII.GetBytes(lenStr);
-                lenStrLength = lenStrBytes.LongLength;
-                Array.Copy(lenStrBytes, 0L, buffer, offset, lenStrLength);
-            }
-
+            long lenStrLength = EncodeDigits(utf8Length, buffer, offset);
             offset += lenStrLength;
             buffer[offset] = 0x3a;  // ':'
             offset++;
@@ -162,56 +185,151 @@ namespace Bencodex
             return 1L + lenStrLength + 1L + utf8.LongLength;
         }
 
-        private static long EncodeList(in List value, byte[] buffer, long offset)
+        // TODO: Needs a unit test.
+        internal static long EncodeList(
+            in List value,
+            IOffloadOptions? offloadOptions,
+            byte[] buffer,
+            long offset
+        )
         {
             buffer[offset] = 0x6c;  // 'l'
-            long encLen = 1L;
-            foreach (IValue el in value)
+            long encLen = 1L;  // This means the logical "expanded" encoding length.
+            long actualBytes = 1L;  // This means the actual "collapsed" encoding length.
+            foreach (IndirectValue el in value.EnumerateIndirectValues())
             {
-                encLen += Encode(el, buffer, offset + encLen);
+                if (offloadOptions is { } oo && !oo.Embeds(el))
+                {
+                    actualBytes += EncodeFingerprint(el.Fingerprint, buffer, offset + actualBytes);
+                    oo.Offload(el, value.Loader);
+                }
+                else
+                {
+                    actualBytes += Encode(
+                        el.GetValue(value.Loader),
+                        offloadOptions,
+                        buffer,
+                        offset + actualBytes
+                    );
+                }
+
+                encLen += el.EncodingLength;
             }
 
-            offset += encLen;
+            offset += actualBytes;
             buffer[offset] = 0x65;  // 'e'
+            actualBytes++;
             encLen++;
             value.EncodingLength = encLen;
-            return encLen;
+            return actualBytes;
         }
 
-        private static long EncodeDictionary(in Dictionary value, byte[] buffer, long offset)
+        // TODO: Needs a unit test.
+        internal static long EncodeDictionary(
+            in Dictionary value,
+            IOffloadOptions? offloadOptions,
+            byte[] buffer,
+            long offset
+        )
         {
             buffer[offset] = 0x64;  // 'd'
-            long encLen = 1L;
-            foreach (KeyValuePair<IKey, IValue> pair in value)
+            long encLen = 1L;  // This means the logical "expanded" encoding length.
+            long actualBytes = 1L;  // This means the actual "collapsed" encoding length.
+            foreach (KeyValuePair<IKey, IndirectValue> pair in value.EnumerateIndirectValues())
             {
-                encLen += pair.Key switch
+                actualBytes += pair.Key switch
                 {
-                    Text tk => EncodeText(tk, buffer, offset + encLen),
-                    Binary bk => EncodeBinary(bk, buffer, offset + encLen),
-                    { } k => Encode(k, buffer, offset + encLen),
+                    Text tk => EncodeText(tk, buffer, offset + actualBytes),
+                    Binary bk => EncodeBinary(bk, buffer, offset + actualBytes),
+                    { } k => Encode(k, offloadOptions, buffer, offset + actualBytes),
                 };
-                encLen += Encode(pair.Value, buffer, offset + encLen);
+                if (offloadOptions is { } oo && !oo.Embeds(pair.Value))
+                {
+                    actualBytes += EncodeFingerprint(pair.Value.Fingerprint, buffer, offset + actualBytes);
+                    oo.Offload(pair.Value, value.Loader);
+                }
+                else
+                {
+                    actualBytes += Encode(
+                        pair.Value.GetValue(value.Loader),
+                        offloadOptions,
+                        buffer,
+                        offset + actualBytes
+                    );
+                }
+
+                encLen += pair.Key.EncodingLength + pair.Value.EncodingLength;
             }
 
-            offset += encLen;
+            offset += actualBytes;
             buffer[offset] = 0x65;  // 'e'
             encLen++;
+            actualBytes++;
             value.EncodingLength = encLen;
-            return encLen;
+            return actualBytes;
         }
 
-        private static long Encode(in IValue value, byte[] buffer, long offset)
+        // TODO: Needs a unit test.
+        internal static long EncodeFingerprint(
+            in Fingerprint fingerprint,
+            byte[] buffer,
+            long offset
+        )
+        {
+            buffer[offset] = 0x2a;  // '*'
+            offset++;
+            long len = fingerprint.CountSerializationBytes();
+            long lenStrLength = EncodeDigits(len, buffer, offset);
+            offset += lenStrLength;
+            buffer[offset] = 0x3a;  // ':'
+            offset++;
+            return 2L + lenStrLength + fingerprint.SerializeInto(buffer, offset);
+        }
+
+        internal static long CountDecimalDigits(long value) => value < 10L
+            ? 1L
+            : value < 100L
+                ? 2L
+                : value < 1000L
+                    ? 3L
+                    : value < 10000L
+                        ? 4L
+                        : (long)Math.Floor(Math.Log10(value)) + 1L;
+
+        internal static long EncodeDigits(long positiveInt, byte[] buffer, long offset)
+        {
+            string digits = positiveInt.ToString(CultureInfo.InvariantCulture);
+            if (offset < int.MaxValue)
+            {
+                return Encoding.ASCII.GetBytes(digits, 0, digits.Length, buffer, (int)offset);
+            }
+
+            byte[] ascii = Encoding.ASCII.GetBytes(digits);
+            Array.Copy(ascii, 0L, buffer, offset, ascii.LongLength);
+            return ascii.Length;
+        }
+
+        // TODO: Needs a unit test.
+        internal static long Encode(
+            in IValue value,
+            IOffloadOptions? offloadOptions,
+            byte[] buffer,
+            long offset
+        )
         {
             return value switch
             {
-                Null n => EncodeNull(n, buffer, offset),
+                Null _ => EncodeNull(buffer, offset),
                 Types.Boolean b => EncodeBoolean(b, buffer, offset),
                 Integer i => EncodeInteger(i, buffer, offset),
                 Binary bin => EncodeBinary(bin, buffer, offset),
                 Text t => EncodeText(t, buffer, offset),
-                List l => EncodeList(l, buffer, offset),
-                Dictionary d => EncodeDictionary(d, buffer, offset),
-                _ => throw new ArgumentException("Unsupported type: " + value.GetType().FullName, nameof(value)),
+                List l => EncodeList(l, offloadOptions, buffer, offset),
+                Dictionary d => EncodeDictionary(d, offloadOptions, buffer, offset),
+                _ =>
+                    throw new ArgumentException(
+                        "Unsupported type: " + value.GetType().FullName, nameof(value)
+                    ),
             };
         }
     }

--- a/Bencodex/IOffloadOptions.cs
+++ b/Bencodex/IOffloadOptions.cs
@@ -9,11 +9,14 @@ namespace Bencodex
     {
         /// <summary>
         /// Determines whether a given <paramref name="indirectValue"/> should be embedded or
-        /// offloaded.
+        /// offloaded.  <em>This method must be deterministic.</em>
         /// </summary>
         /// <param name="indirectValue">A value to determine whether to embed or offload.</param>
         /// <returns><see langword="true"/> if <paramref name="indirectValue"/> should be embedded;
         /// <see langword="false"/> if it should be offloaded.</returns>
+        /// <remarks>Note that returning <see langword="true"/> does not mean the entire value
+        /// including its subvalues is embedded, but only the container is.  Subvalues in it
+        /// are separately determined using distinct calls on this method.</remarks>
         public bool Embeds(in IndirectValue indirectValue);
 
         /// <summary>

--- a/Bencodex/IOffloadOptions.cs
+++ b/Bencodex/IOffloadOptions.cs
@@ -1,0 +1,28 @@
+﻿using Bencodex.Types;
+
+namespace Bencodex
+{
+    /// <summary>
+    /// Options specifying how to offload heavy values of lists and dictionaries.
+    /// </summary>
+    public interface IOffloadOptions
+    {
+        /// <summary>
+        /// Determines whether a given <paramref name="indirectValue"/> should be embedded or
+        /// offloaded.
+        /// </summary>
+        /// <param name="indirectValue">A value to determine whether to embed or offload.</param>
+        /// <returns><see langword="true"/> if <paramref name="indirectValue"/> should be embedded;
+        /// <see langword="false"/> if it should be offloaded.</returns>
+        public bool Embeds(in IndirectValue indirectValue);
+
+        /// <summary>
+        /// Stores an offloaded value in a separate place.
+        /// </summary>
+        /// <param name="indirectValue">An offloaded value.</param>
+        /// <param name="loader">An optional loader used for loading
+        /// the <paramref name="indirectValue"/>.  This can be <see langword="null"/> if
+        /// the <paramref name="indirectValue"/> is already loaded.</param>
+        public void Offload(in IndirectValue indirectValue, IndirectValue.Loader? loader);
+    }
+}

--- a/Bencodex/OffloadOptions.cs
+++ b/Bencodex/OffloadOptions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Bencodex.Types;
+
+namespace Bencodex
+{
+    /// <summary>
+    /// Options specifying how to offload heavy values of lists and dictionaries.
+    /// </summary>
+    public sealed class OffloadOptions : IOffloadOptions
+    {
+        private readonly Predicate<IndirectValue> _embedPredicate;
+        private readonly Action<IndirectValue, IndirectValue.Loader?> _offloadAction;
+
+        /// <summary>
+        /// Creates a new instance of <see cref="OffloadOptions"/>.
+        /// </summary>
+        /// <param name="embedPredicate">A predicate to implement <see cref="Embeds"/> method.
+        /// </param>
+        /// <param name="offloadAction">An action to implement <see cref="Offload"/> method.</param>
+        public OffloadOptions(
+            Predicate<IndirectValue> embedPredicate,
+            Action<IndirectValue, IndirectValue.Loader?> offloadAction
+        )
+        {
+            _embedPredicate = embedPredicate;
+            _offloadAction = offloadAction;
+        }
+
+        /// <inheritdoc cref="IOffloadOptions.Embeds"/>
+        public bool Embeds(in IndirectValue indirectValue) =>
+            _embedPredicate(indirectValue);
+
+        /// <inheritdoc cref="IOffloadOptions.Offload"/>
+        public void Offload(in IndirectValue indirectValue, IndirectValue.Loader? loader) =>
+            _offloadAction(indirectValue, loader);
+    }
+}

--- a/Bencodex/Types/IndirectValue.cs
+++ b/Bencodex/Types/IndirectValue.cs
@@ -60,7 +60,7 @@ namespace Bencodex.Types
         /// </summary>
         /// <exception cref="InvalidOperationException">Thrown when the <see cref="IndirectValue"/>
         /// is an uninitialized default value.</exception>
-        public ValueKind Type => LoadedValue is { } loaded ? loaded.Kind : Fingerprint.Kind;
+        public ValueKind Kind => LoadedValue is { } loaded ? loaded.Kind : Fingerprint.Kind;
 
         /// <summary>
         /// The encoding length of the value that this <see cref="IndirectValue"/> refers to.

--- a/Bencodex/Types/Integer.cs
+++ b/Bencodex/Types/Integer.cs
@@ -79,7 +79,7 @@ namespace Bencodex.Types
         /// <inheritdoc cref="IValue.EncodingLength"/>
         [Pure]
         public long EncodingLength =>
-            2L + Value.ToString(CultureInfo.InvariantCulture).Length;
+            2L + CountDecimalDigits();
 
         /// <inheritdoc cref="IValue.Inspection"/>
         [Obsolete("Deprecated in favour of " + nameof(Inspect) + "() method.")]
@@ -245,5 +245,29 @@ namespace Bencodex.Types
         /// <inheritdoc cref="object.ToString()"/>
         public override string ToString() =>
             $"{nameof(Bencodex)}.{nameof(Types)}.{nameof(Integer)} {Inspect(false)}";
+
+        internal long CountDecimalDigits() =>
+            Value.Sign switch
+            {
+                -1 => Value > -10L
+                    ? 2L
+                    : Value > -100L
+                        ? 3L
+                        : Value > -1000L
+                            ? 4L
+                            : Value > -10000L
+                                ? 5L
+                                : Value.ToString(CultureInfo.InvariantCulture).Length,
+                +1 => Value < 10UL
+                    ? 1L
+                    : Value < 100UL
+                        ? 2L
+                        : Value < 1000UL
+                            ? 3L
+                            : Value < 10000UL
+                                ? 4L
+                                : Value.ToString(CultureInfo.InvariantCulture).Length,
+                _ => 1L,
+            };
     }
 }

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -381,7 +381,7 @@ namespace Bencodex.Types
 
                 case 1:
                     IndirectValue first = _values[0];
-                    if (first.Type == ValueKind.List || first.Type == ValueKind.Dictionary)
+                    if (first.Kind == ValueKind.List || first.Kind == ValueKind.Dictionary)
                     {
                         goto default;
                     }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,10 @@ To be released.
     `IEquatable<Bencodex.Types.Dictionary>` interface.  [[#51]]
  -  Added `Bencodex.Types.ValueKind` enum type.  [[#50], [#53]]
  -  Bencodex lists and dictionaries now can offload their elements:
+     -  Added `Codec.Encode(IValue, IOffloadOptions?)` overloaded method.
+        [[#55]]
+     -  Added `Codec.Encode(IValue, Stream, IOffloadOptions?)` overloaded
+        method.  [[#55]]
      -  Added `Bencodex.Types.IndirectValue` struct.  [[#52]]
      -  Added `List(IEnumerable<IndirectValue>, IndirectValue.Loader)`
         constructor.  [[#52]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,10 @@ To be released.
         [[#55]]
      -  Added `Codec.Encode(IValue, Stream, IOffloadOptions?)` overloaded
         method.  [[#55]]
+     -  Added `Codec.Decode(byte[], IndirectValue.Loader?)` overloaded method.
+        [[#55]]
+     -  Added `Codec.Decode(Stream, IndirectValue.Loader?)` overloaded method.
+        [[#55]]
      -  Added `Bencodex.Types.IndirectValue` struct.  [[#52]]
      -  Added `List(IEnumerable<IndirectValue>, IndirectValue.Loader)`
         constructor.  [[#52]]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,8 +20,8 @@ To be released.
         constructor.  [[#52]]
      -  Added `Dictionary(IEnumerable<KeyValuePair<IKey, IndirectValue>>,
         IndirectValue.Loader)` constructor.  [[#52]]
-     -  Added `List.EnumerateIndirectValues()` method.  [[#53]]
-     -  Added `Dictionary.EnumerateIndirectValues()` method.  [[#53]]
+     -  Added `Bencodex.IOffloadOptions` interface. [[#55]]
+     -  Added `Bencodex.OffloadOptions` sealed class. [[#55]]
  -  Bencodex values now have their unique fingerprints:  [[#50]]
      -  Added `Bencodex.Types.Fingerprint` readonly struct.
      -  Added `Bencodex.Misc.FingerprintComparer` class.
@@ -61,6 +61,7 @@ To be released.
 [#52]: https://github.com/planetarium/bencodex.net/pull/52
 [#53]: https://github.com/planetarium/bencodex.net/pull/53
 [#54]: https://github.com/planetarium/bencodex.net/pull/54
+[#55]: https://github.com/planetarium/bencodex.net/pull/55
 
 
 Version 0.3.0


### PR DESCRIPTION
*Continued from the pull request #52.*

This enable `Codec` to directly encode and decode offloaded values.  In serialized encoding, these offloaded values are represented as like (see also `EncoderTest.Offload()`):

- `2A` (ASCII `*`)[^1]
- the length of fingerprint bytes in ASCII decimal digits[^2]
- `3A` (ASCII `:`)
- fingerprint bytes[^3]

Note that this extended format is not included in the Bencodex spec.  It is currently just Bencodex.NET's own extension.  (Would it be addressed by the Bencodex spec?)

[^1]: This first one is a identifying byte among Bencodex's other identifiers like `i` (Integer), `l` (list).
[^2]: E.g., `31` `36` (ASCII `1` `6`) for 16-bytes fingerprint.
[^3]: It follows its own distinct encoding format, which was defined in the previous PR #50.  See also `Fingerprint.Serialize()` and `Fingerprint.Deserialize()` methods.