### PR TITLE
Additional type support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Bencodex.Tests/spec"]
 	path = Bencodex.Tests/spec
-	url = git://github.com/planetarium/bencodex.git
+	url = https://github.com/planetarium/bencodex.git

--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -288,6 +288,8 @@ namespace Bencodex.Tests.Types
             byte[] binaryKey = new byte[] { 0x02 };
             byte[] booleanKey = new byte[] { 0x03 };
             byte[] listKey = new byte[] { 0x04 };
+
+            // NOTE: Assigned multiple times with the same values for checking syntax.
             var dictionary = Dictionary.Empty
                 .Add("text", "foo")
                 .Add("integer", 1337)
@@ -299,6 +301,42 @@ namespace Bencodex.Tests.Types
                 .Add(binaryKey, new byte[] { 0x05, 0x06, 0x07, 0x08 })
                 .Add(booleanKey, false)
                 .Add(listKey, new IValue[] { (Text)"qux", (Integer)2020 });
+
+            dictionary = Dictionary.Empty
+                .Add((Text)"text", "foo")
+                .Add((Text)"integer", 1337)
+                .Add((Text)"binary", new byte[] { 0x01, 0x02, 0x03, 0x04 })
+                .Add((Text)"boolean", true)
+                .Add((Text)"list", new IValue[] { (Text)"bar", (Integer)1337 })
+                .Add((Binary)textKey, "baz")
+                .Add((Binary)integerKey, 2020)
+                .Add((Binary)binaryKey, new byte[] { 0x05, 0x06, 0x07, 0x08 })
+                .Add((Binary)booleanKey, false)
+                .Add((Binary)listKey, new IValue[] { (Text)"qux", (Integer)2020 });
+
+            dictionary = Dictionary.Empty
+                .Add("text", (Text)"foo")
+                .Add("integer", (Integer)1337)
+                .Add("binary", (Binary)new byte[] { 0x01, 0x02, 0x03, 0x04 })
+                .Add("boolean", (Bencodex.Types.Boolean)true)
+                .Add("list", new List(new IValue[] { (Text)"bar", (Integer)1337 }))
+                .Add(textKey, (Text)"baz")
+                .Add(integerKey, (Integer)2020)
+                .Add(binaryKey, (Binary)new byte[] { 0x05, 0x06, 0x07, 0x08 })
+                .Add(booleanKey, (Bencodex.Types.Boolean)false)
+                .Add(listKey, new List(new IValue[] { (Text)"qux", (Integer)2020 }));
+
+            dictionary = Dictionary.Empty
+                .Add((Text)"text", (Text)"foo")
+                .Add((Text)"integer", (Integer)1337)
+                .Add((Text)"binary", (Binary)new byte[] { 0x01, 0x02, 0x03, 0x04 })
+                .Add((Text)"boolean", (Bencodex.Types.Boolean)true)
+                .Add((Text)"list", new List(new IValue[] { (Text)"bar", (Integer)1337 }))
+                .Add((Binary)textKey, (Text)"baz")
+                .Add((Binary)integerKey, (Integer)2020)
+                .Add((Binary)binaryKey, (Binary)new byte[] { 0x05, 0x06, 0x07, 0x08 })
+                .Add((Binary)booleanKey, (Bencodex.Types.Boolean)false)
+                .Add((Binary)listKey, new List(new IValue[] { (Text)"qux", (Integer)2020 }));
 
             // String keys
             Assert.Equal("foo", (Text)dictionary["text"]);

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -344,7 +344,18 @@ namespace Bencodex.Tests.Types
                 .Add("foo")
                 .Add(Encoding.UTF8.GetBytes("bar"))
                 .Add(0xbeef)
-                .Add(true)
+                .Add(true);
+
+            Assert.Equal((Text)"foo", list[0]);
+            Assert.Equal((Binary)Encoding.UTF8.GetBytes("bar"), list[1]);
+            Assert.Equal((Integer)0xbeef, list[2]);
+            Assert.Equal((Boolean)true, list[3]);
+
+            list = List.Empty
+                .Add((Text)"foo")
+                .Add((Binary)Encoding.UTF8.GetBytes("bar"))
+                .Add((Integer)0xbeef)
+                .Add((Boolean)true)
                 .Add(List.Empty)
                 .Add(Dictionary.Empty);
 

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -279,61 +279,245 @@ namespace Bencodex.Types
         public IImmutableDictionary<IKey, IValue> Add(IKey key, IValue value) =>
             new Dictionary(_dict.Add(key, new IndirectValue(value)), Loader);
 
+        public Dictionary Add(Text key, IValue value) =>
+            (Dictionary)Add((IKey)key, value);
+
+        public Dictionary Add(Text key, Text value) =>
+            Add(key, (IValue)value);
+
+        public Dictionary Add(Text key, Boolean value) =>
+            Add(key, (IValue)value);
+
+        public Dictionary Add(Text key, Integer value) =>
+            Add(key, (IValue)value);
+
+        public Dictionary Add(Text key, Binary value) =>
+            Add(key, (IValue)value);
+
+        public Dictionary Add(Text key, List value) =>
+            Add(key, (IValue)value);
+
+        public Dictionary Add(Text key, Dictionary value) =>
+            Add(key, (IValue)value);
+
+        public Dictionary Add(Text key, string value) =>
+            Add(key, new Text(value));
+
+        public Dictionary Add(Text key, int value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(Text key, uint value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(Text key, long value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(Text key, ulong value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(Text key, ImmutableArray<byte> value) =>
+            Add(key, new Binary(value));
+
+        public Dictionary Add(Text key, byte[] value) =>
+            Add(key, new Binary(value));
+
+        public Dictionary Add(Text key, bool value) =>
+            Add(key, new Boolean(value));
+
+        public Dictionary Add(Text key, IEnumerable<IValue> value) =>
+            Add(key, new List(value));
+
+        public Dictionary Add(Binary key, IValue value) =>
+            (Dictionary)Add((IKey)key, value);
+
+        public Dictionary Add(Binary key, Text value) =>
+            Add(key, (IValue)value);
+
+        public Dictionary Add(Binary key, Boolean value) =>
+            Add(key, (IValue)value);
+
+        public Dictionary Add(Binary key, Integer value) =>
+            Add(key, (IValue)value);
+
+        public Dictionary Add(Binary key, Binary value) =>
+            Add(key, (IValue)value);
+
+        public Dictionary Add(Binary key, List value) =>
+            Add(key, (IValue)value);
+
+        public Dictionary Add(Binary key, Dictionary value) =>
+            Add(key, (IValue)value);
+
+        public Dictionary Add(Binary key, string value) =>
+            Add(key, new Text(value));
+
+        public Dictionary Add(Binary key, int value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(Binary key, uint value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(Binary key, long value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(Binary key, ulong value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(Binary key, ImmutableArray<byte> value) =>
+            Add(key, new Binary(value));
+
+        public Dictionary Add(Binary key, byte[] value) =>
+            Add(key, new Binary(value));
+
+        public Dictionary Add(Binary key, bool value) =>
+            Add(key, new Boolean(value));
+
+        public Dictionary Add(Binary key, IEnumerable<IValue> value) =>
+            Add(key, new List(value));
+
         public Dictionary Add(string key, IValue value) =>
-            (Dictionary)Add((IKey)new Text(key), value);
+            Add(new Text(key), value);
 
-        public Dictionary Add(string key, string value) => Add(key, (IValue)new Text(value));
+        public Dictionary Add(string key, Text value) =>
+            Add(new Text(key), value);
 
-        public Dictionary Add(string key, long value) => Add(key, (IValue)new Integer(value));
+        public Dictionary Add(string key, Boolean value) =>
+            Add(new Text(key), value);
 
-        public Dictionary Add(string key, ulong value) => Add(key, (IValue)new Integer(value));
+        public Dictionary Add(string key, Integer value) =>
+            Add(new Text(key), value);
+
+        public Dictionary Add(string key, Binary value) =>
+            Add(new Text(key), value);
+
+        public Dictionary Add(string key, List value) =>
+            Add(new Text(key), value);
+
+        public Dictionary Add(string key, Dictionary value) =>
+            Add(new Text(key), value);
+
+        public Dictionary Add(string key, string value) =>
+            Add(key, new Text(value));
+
+        public Dictionary Add(string key, int value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(string key, uint value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(string key, long value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(string key, ulong value) =>
+            Add(key, new Integer(value));
 
         public Dictionary Add(string key, ImmutableArray<byte> value) =>
-            Add(key, (IValue)new Binary(value));
+            Add(key, new Binary(value));
 
-        public Dictionary Add(string key, byte[] value) => Add(key, (IValue)new Binary(value));
+        public Dictionary Add(string key, byte[] value) =>
+            Add(key, new Binary(value));
 
-        public Dictionary Add(string key, bool value) => Add(key, (IValue)new Boolean(value));
+        public Dictionary Add(string key, bool value) =>
+            Add(key, new Boolean(value));
 
         public Dictionary Add(string key, IEnumerable<IValue> value) =>
-            Add(key, (IValue)new List(value));
+            Add(key, new List(value));
 
         public Dictionary Add(ImmutableArray<byte> key, IValue value) =>
-            (Dictionary)Add((IKey)new Binary(key), value);
+            Add(new Binary(key), value);
 
-        public Dictionary Add(ImmutableArray<byte> key, string value) => Add(key, (IValue)new Text(value));
+        public Dictionary Add(ImmutableArray<byte> key, Text value) =>
+            Add(new Binary(key), value);
 
-        public Dictionary Add(ImmutableArray<byte> key, long value) => Add(key, (IValue)new Integer(value));
+        public Dictionary Add(ImmutableArray<byte> key, Boolean value) =>
+            Add(new Binary(key), value);
 
-        public Dictionary Add(ImmutableArray<byte> key, ulong value) => Add(key, (IValue)new Integer(value));
+        public Dictionary Add(ImmutableArray<byte> key, Integer value) =>
+            Add(new Binary(key), value);
+
+        public Dictionary Add(ImmutableArray<byte> key, Binary value) =>
+            Add(new Binary(key), value);
+
+        public Dictionary Add(ImmutableArray<byte> key, List value) =>
+            Add(new Binary(key), value);
+
+        public Dictionary Add(ImmutableArray<byte> key, Dictionary value) =>
+            Add(new Binary(key), value);
+
+        public Dictionary Add(ImmutableArray<byte> key, string value) =>
+            Add(key, new Text(value));
+
+        public Dictionary Add(ImmutableArray<byte> key, int value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(ImmutableArray<byte> key, uint value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(ImmutableArray<byte> key, long value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(ImmutableArray<byte> key, ulong value) =>
+            Add(key, new Integer(value));
 
         public Dictionary Add(ImmutableArray<byte> key, ImmutableArray<byte> value) =>
-            Add(key, (IValue)new Binary(value));
+            Add(key, new Binary(value));
 
-        public Dictionary Add(ImmutableArray<byte> key, byte[] value) => Add(key, (IValue)new Binary(value));
+        public Dictionary Add(ImmutableArray<byte> key, byte[] value) =>
+            Add(key, new Binary(value));
 
-        public Dictionary Add(ImmutableArray<byte> key, bool value) => Add(key, (IValue)new Boolean(value));
+        public Dictionary Add(ImmutableArray<byte> key, bool value) =>
+            Add(key, new Boolean(value));
 
         public Dictionary Add(ImmutableArray<byte> key, IEnumerable<IValue> value) =>
-            Add(key, (IValue)new List(value));
+            Add(key, new List(value));
 
         public Dictionary Add(byte[] key, IValue value) =>
-            (Dictionary)Add((IKey)new Binary(key), value);
+            Add(new Binary(key), value);
 
-        public Dictionary Add(byte[] key, string value) => Add(key, (IValue)new Text(value));
+        public Dictionary Add(byte[] key, Text value) =>
+            Add(new Binary(key), value);
 
-        public Dictionary Add(byte[] key, long value) => Add(key, (IValue)new Integer(value));
+        public Dictionary Add(byte[] key, Boolean value) =>
+            Add(new Binary(key), value);
 
-        public Dictionary Add(byte[] key, ulong value) => Add(key, (IValue)new Integer(value));
+        public Dictionary Add(byte[] key, Integer value) =>
+            Add(new Binary(key), value);
 
-        public Dictionary Add(byte[] key, ImmutableArray<byte> value) => Add(key, (IValue)new Binary(value));
+        public Dictionary Add(byte[] key, Binary value) =>
+            Add(new Binary(key), value);
 
-        public Dictionary Add(byte[] key, byte[] value) => Add(key, (IValue)new Binary(value));
+        public Dictionary Add(byte[] key, List value) =>
+            Add(new Binary(key), value);
 
-        public Dictionary Add(byte[] key, bool value) => Add(key, (IValue)new Boolean(value));
+        public Dictionary Add(byte[] key, Dictionary value) =>
+            Add(new Binary(key), value);
+
+        public Dictionary Add(byte[] key, string value) =>
+            Add(key, new Text(value));
+
+        public Dictionary Add(byte[] key, int value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(byte[] key, uint value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(byte[] key, long value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(byte[] key, ulong value) =>
+            Add(key, new Integer(value));
+
+        public Dictionary Add(byte[] key, ImmutableArray<byte> value) =>
+            Add(key, new Binary(value));
+
+        public Dictionary Add(byte[] key, byte[] value) =>
+            Add(key, new Binary(value));
+
+        public Dictionary Add(byte[] key, bool value) =>
+            Add(key, new Boolean(value));
 
         public Dictionary Add(byte[] key, IEnumerable<IValue> value) =>
-            Add(key, (IValue)new List(value));
+            Add(key, new List(value));
 
         /// <inheritdoc cref="IImmutableDictionary{TKey,TValue}.AddRange"/>
         public IImmutableDictionary<IKey, IValue> AddRange(

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -222,11 +222,39 @@ namespace Bencodex.Types
 
         /// <summary>Makes a copy of the list, and adds the specified <paramref name="value"/>
         /// to the end of the copied list.</summary>
+        /// <param name="value">The value to add to the list.</param>
+        /// <returns>A new list with the value added.</returns>
+        public List Add(Text value) =>
+            Add((IValue)value);
+
+        /// <summary>Makes a copy of the list, and adds the specified <paramref name="value"/>
+        /// to the end of the copied list.</summary>
+        /// <param name="value">The value to add to the list.</param>
+        /// <returns>A new list with the value added.</returns>
+        public List Add(Boolean value) =>
+            Add((IValue)value);
+
+        /// <summary>Makes a copy of the list, and adds the specified <paramref name="value"/>
+        /// to the end of the copied list.</summary>
+        /// <param name="value">The value to add to the list.</param>
+        /// <returns>A new list with the value added.</returns>
+        public List Add(Integer value) =>
+            Add((IValue)value);
+
+        /// <summary>Makes a copy of the list, and adds the specified <paramref name="value"/>
+        /// to the end of the copied list.</summary>
+        /// <param name="value">The value to add to the list.</param>
+        /// <returns>A new list with the value added.</returns>
+        public List Add(Binary value) =>
+            Add((IValue)value);
+
+        /// <summary>Makes a copy of the list, and adds the specified <paramref name="value"/>
+        /// to the end of the copied list.</summary>
         /// <param name="value">The value to add to the list.  It is automatically turned into
         /// a Bencodex <see cref="Text"/> instance.</param>
         /// <returns>A new list with the value added.</returns>
         public List Add(string value) =>
-            Add((IValue)new Text(value));
+            Add(new Text(value));
 
         /// <summary>Makes a copy of the list, and adds the specified <paramref name="value"/>
         /// to the end of the copied list.</summary>
@@ -234,7 +262,7 @@ namespace Bencodex.Types
         /// a Bencodex <see cref="Boolean"/> instance.</param>
         /// <returns>A new list with the value added.</returns>
         public List Add(bool value) =>
-            Add((IValue)new Boolean(value));
+            Add(new Boolean(value));
 
         /// <summary>Makes a copy of the list, and adds the specified <paramref name="value"/>
         /// to the end of the copied list.</summary>
@@ -242,7 +270,23 @@ namespace Bencodex.Types
         /// a Bencodex <see cref="Integer"/> instance.</param>
         /// <returns>A new list with the value added.</returns>
         public List Add(BigInteger value) =>
-            Add((IValue)new Integer(value));
+            Add(new Integer(value));
+
+        /// <summary>Makes a copy of the list, and adds the specified <paramref name="value"/>
+        /// to the end of the copied list.</summary>
+        /// <param name="value">The value to add to the list.  It is automatically turned into
+        /// a Bencodex <see cref="Integer"/> instance.</param>
+        /// <returns>A new list with the value added.</returns>
+        public List Add(int value) =>
+            Add(new BigInteger(value));
+
+        /// <summary>Makes a copy of the list, and adds the specified <paramref name="value"/>
+        /// to the end of the copied list.</summary>
+        /// <param name="value">The value to add to the list.  It is automatically turned into
+        /// a Bencodex <see cref="Integer"/> instance.</param>
+        /// <returns>A new list with the value added.</returns>
+        public List Add(long value) =>
+            Add(new BigInteger(value));
 
         /// <summary>Makes a copy of the list, and adds the specified <paramref name="value"/>
         /// to the end of the copied list.</summary>
@@ -250,7 +294,7 @@ namespace Bencodex.Types
         /// a Bencodex <see cref="Binary"/> instance.</param>
         /// <returns>A new list with the value added.</returns>
         public List Add(byte[] value) =>
-            Add((IValue)new Binary(value));
+            Add(new Binary(value));
 
         IImmutableList<IValue> IImmutableList<IValue>.AddRange(
             IEnumerable<IValue> items

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ Version 0.5.0
 
 To be released.
 
+ -  `Bencodex.Types.List.Add()` now directly supports `Text`, `Boolean`,
+    `Integer`, and `Binary` types.  [[#58], [#60]]
+ -  `Bencodex.Types.Dictionary.Add()` now directly supports `Text`, `Boolean`,
+    `Integer`, and `Binary` types.  [[#58], [#60]]
+
+[#58]: https://github.com/planetarium/bencodex.net/issues/58
+[#60]: https://github.com/planetarium/bencodex.net/pull/60
+
 
 Version 0.4.0
 -------------


### PR DESCRIPTION
Resolves #58.

In general, redirections of `Add()` for type conversions and/or casting are done more systematically. For instance, when trying to add `(string, string)` to a `Dictionary`, the conversion path is

```
(string, string) -> (string, Text) -> (Text, Text) -> (Text, IValue) -> (IKey, IValue)
```

There could be a slight performance hit for certain cases, but in my opinion, this would make client-side code a lot easier to optimize and would probably increase overall performance.

For example, in the old scheme, when trying to add `(Text, Text)` to a dictionary, it is easy to make the following mistake.

```csharp
Text foo = new Text("foo");
Text bar = new Text("bar");
Dictionary dict = Dictionary.Empty.Add((string)foo, (string)bar);
```

As a result, explicit conversion from `Text` to `string` and an additional implicit internal conversion from `string` to `Text` would happen unnecessarily. With this PR, we can now do

```csharp
Text foo = new Text("foo");
Text bar = new Text("bar");
Dictionary dict = Dictionary.Empty.Add(foo, bar);
```

where only relatively light type casting would be necessary internally.