### PR TITLE
Additional type support for `List` and `Dictionary` constructors

### DIFF
--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -76,6 +76,54 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
+        public void ParameterTypesForConstructors()
+        {
+            Dictionary<string, byte[]> stringBytesDict = new Dictionary<string, byte[]>
+            {
+                { "foo", new byte[] { 1, 2 } },
+                { "bar", new byte[] { 3, 4, 5 } },
+            };
+            Dictionary<string, Binary> stringBinarydict = stringBytesDict.ToDictionary(
+                pair => pair.Key, pair => (Binary)pair.Value);
+            Dictionary<string, IValue> stringValueDict = stringBytesDict.ToDictionary(
+                pair => pair.Key, pair => (IValue)(Binary)pair.Value);
+            Dictionary<Text, byte[]> textBytesDict = stringBytesDict.ToDictionary(
+                pair => (Text)pair.Key, pair => pair.Value);
+            Dictionary<Text, Binary> textBinaryDict = stringBytesDict.ToDictionary(
+                pair => (Text)pair.Key, pair => (Binary)pair.Value);
+            Dictionary<Text, IValue> textValueDict = stringBytesDict.ToDictionary(
+                pair => (Text)pair.Key, pair => (IValue)(Binary)pair.Value);
+
+            Assert.Equal(new Dictionary(stringBytesDict), new Dictionary(stringBinarydict));
+            Assert.Equal(new Dictionary(stringBytesDict), new Dictionary(stringValueDict));
+            Assert.Equal(new Dictionary(stringBytesDict), new Dictionary(textBytesDict));
+            Assert.Equal(new Dictionary(stringBytesDict), new Dictionary(textBinaryDict));
+            Assert.Equal(new Dictionary(stringBytesDict), new Dictionary(textValueDict));
+
+            Dictionary<byte[], int> bytesIntDict = new Dictionary<byte[], int>
+            {
+                { new byte[] { 1, 2, 3 }, 4 },
+                { new byte[] { 5, 6, 7, 8 }, 9 },
+            };
+            Dictionary<byte[], Integer> bytesIntegerDict = bytesIntDict.ToDictionary(
+                pair => pair.Key, pair => (Integer)pair.Value);
+            Dictionary<byte[], IValue> bytesValueDict = bytesIntDict.ToDictionary(
+                pair => pair.Key, pair => (IValue)(Integer)pair.Value);
+            Dictionary<Binary, int> binaryIntDict = bytesIntDict.ToDictionary(
+                pair => (Binary)pair.Key, pair => pair.Value);
+            Dictionary<Binary, Integer> binaryIntegerDict = bytesIntDict.ToDictionary(
+                pair => (Binary)pair.Key, pair => (Integer)pair.Value);
+            Dictionary<Binary, IValue> binaryValueDict = bytesIntDict.ToDictionary(
+                pair => (Binary)pair.Key, pair => (IValue)(Integer)pair.Value);
+
+            Assert.Equal(new Dictionary(bytesIntDict), new Dictionary(bytesIntegerDict));
+            Assert.Equal(new Dictionary(bytesIntDict), new Dictionary(bytesValueDict));
+            Assert.Equal(new Dictionary(bytesIntDict), new Dictionary(binaryIntDict));
+            Assert.Equal(new Dictionary(bytesIntDict), new Dictionary(binaryIntegerDict));
+            Assert.Equal(new Dictionary(bytesIntDict), new Dictionary(binaryValueDict));
+        }
+
+        [Fact]
         public void Equality()
         {
             var a = new Dictionary(new KeyValuePair<IKey, IValue>[]

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -54,8 +54,7 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void Constructors()
         {
-            Assert.Equal(_zero, new List(Enumerable.Empty<IValue>())
-            );
+            Assert.Equal(_zero, new List(Enumerable.Empty<IValue>()));
             Assert.Equal(
                 new List(ImmutableArray<IValue>.Empty.Add(Null.Value)),
                 new List(Enumerable.Empty<IValue>().Append(Null.Value))
@@ -76,6 +75,32 @@ namespace Bencodex.Tests.Types
                 _one.Add(_zero).Add(_one).Add(_two),
                 new List(Null.Value, _zero, _one, _two)
             );
+        }
+
+        [Fact]
+        public void ParameterTypesForConstructors()
+        {
+            List<string> strings = new List<string>() { "foo", "bar", "baz" };
+            List<Text> texts = strings.Select(s => (Text)s).ToList();
+            List<int> ints = new List<int>() { 0, 1, 2 };
+            List<Integer> integers = ints.Select(i => (Integer)i).ToList();
+            List<byte[]> byteArrays = new List<byte[]>() {
+                new byte[] { 1, 2 },
+                new byte[] { 3, 4, 5 },
+            };
+            List<Binary> binaries = byteArrays.Select(bs => (Binary)bs).ToList();
+
+            List list1 = new List(strings);
+            List list2 = new List(texts);
+            Assert.Equal(list1, list2);
+
+            list1 = new List(ints);
+            list2 = new List(integers);
+            Assert.Equal(list1, list2);
+
+            list1 = new List(byteArrays);
+            list2 = new List(binaries);
+            Assert.Equal(list1, list2);
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -80,27 +80,20 @@ namespace Bencodex.Tests.Types
         [Fact]
         public void ParameterTypesForConstructors()
         {
-            List<string> strings = new List<string>() { "foo", "bar", "baz" };
-            List<Text> texts = strings.Select(s => (Text)s).ToList();
-            List<int> ints = new List<int>() { 0, 1, 2 };
-            List<Integer> integers = ints.Select(i => (Integer)i).ToList();
-            List<byte[]> byteArrays = new List<byte[]>() {
+            List<string> stringList = new List<string>() { "foo", "bar", "baz" };
+            List<Text> textList = stringList.Select(s => (Text)s).ToList();
+            List<int> intList = new List<int> { 0, 1, 2 };
+            List<Integer> integerList = intList.Select(i => (Integer)i).ToList();
+            List<byte[]> bytesList = new List<byte[]>
+            {
                 new byte[] { 1, 2 },
                 new byte[] { 3, 4, 5 },
             };
-            List<Binary> binaries = byteArrays.Select(bs => (Binary)bs).ToList();
+            List<Binary> binaryList = bytesList.Select(bs => (Binary)bs).ToList();
 
-            List list1 = new List(strings);
-            List list2 = new List(texts);
-            Assert.Equal(list1, list2);
-
-            list1 = new List(ints);
-            list2 = new List(integers);
-            Assert.Equal(list1, list2);
-
-            list1 = new List(byteArrays);
-            list2 = new List(binaries);
-            Assert.Equal(list1, list2);
+            Assert.Equal(new List(stringList), new List(textList));
+            Assert.Equal(new List(intList), new List(integerList));
+            Assert.Equal(new List(bytesList), new List(binaryList));
         }
 
         [Fact]

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -56,426 +56,851 @@ namespace Bencodex.Types
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, IValue>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, Boolean>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, Integer>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, Binary>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, Text>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, List>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, Dictionary>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, bool>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Boolean(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, short>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, ushort>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, int>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, uint>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, long>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, ulong>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, byte[]>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Binary(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, ImmutableArray<byte>>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Binary(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Text, string>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Text(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, IValue>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, Boolean>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, Integer>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, Binary>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, Text>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, List>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, Dictionary>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, bool>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Boolean(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, short>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, ushort>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, int>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, uint>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, long>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, ulong>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, byte[]>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Binary(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, ImmutableArray<byte>>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Binary(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<Binary, string>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Text(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, IValue>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, Boolean>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, Integer>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, Binary>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, Text>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, List>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, Dictionary>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, bool>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Boolean(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, short>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, ushort>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, int>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, uint>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, long>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, ulong>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, byte[]>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Binary(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, ImmutableArray<byte>>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Binary(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<string, string>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Text(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], IValue>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], Boolean>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], Integer>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], Binary>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], Text>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], List>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], Dictionary>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], bool>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Boolean(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], short>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], ushort>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], int>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], uint>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], long>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], ulong>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], byte[]>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Binary(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], ImmutableArray<byte>>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Binary(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<byte[], string>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Text(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, IValue>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, Boolean>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, Integer>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, Binary>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, Text>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, List>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, Dictionary>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, bool>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Boolean(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, short>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, ushort>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, int>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, uint>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, long>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, ulong>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, byte[]>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Binary(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, ImmutableArray<byte>>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Binary(p.Value))))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="Dictionary"/> instance with key-value <paramref name="pairs"/>.
+        /// </summary>
+        /// <param name="pairs">Key-value pairs to include.  If there are duplicated keys,
+        /// later pairs overwrite earlier ones.</param>
         public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, string>> pairs)
             : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Text(p.Value))))
         {

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -56,6 +56,431 @@ namespace Bencodex.Types
         {
         }
 
+        public Dictionary(IEnumerable<KeyValuePair<Text, IValue>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, Boolean>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, Integer>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, Binary>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, Text>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, List>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, Dictionary>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, bool>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Boolean(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, short>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, ushort>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, int>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, uint>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, long>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, ulong>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, byte[]>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Binary(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, ImmutableArray<byte>>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Binary(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Text, string>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Text(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, IValue>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, Boolean>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, Integer>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, Binary>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, Text>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, List>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, Dictionary>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, bool>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Boolean(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, short>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, ushort>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, int>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, uint>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, long>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, ulong>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, byte[]>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Binary(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, ImmutableArray<byte>>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Binary(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<Binary, string>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(p.Key, new Text(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, IValue>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, Boolean>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, Integer>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, Binary>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, Text>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, List>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, Dictionary>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, bool>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Boolean(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, short>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, ushort>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, int>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, uint>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, long>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, ulong>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, byte[]>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Binary(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, ImmutableArray<byte>>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Binary(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<string, string>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Text(p.Key), new Text(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], IValue>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], Boolean>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], Integer>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], Binary>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], Text>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], List>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], Dictionary>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], bool>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Boolean(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], short>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], ushort>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], int>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], uint>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], long>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], ulong>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], byte[]>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Binary(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], ImmutableArray<byte>>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Binary(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<byte[], string>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Text(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, IValue>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, Boolean>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, Integer>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, Binary>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, Text>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, List>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, Dictionary>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), p.Value)))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, bool>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Boolean(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, short>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, ushort>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, int>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, uint>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, long>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, ulong>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Integer(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, byte[]>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Binary(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, ImmutableArray<byte>>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Binary(p.Value))))
+        {
+        }
+
+        public Dictionary(IEnumerable<KeyValuePair<ImmutableArray<byte>, string>> pairs)
+            : this(pairs.Select(p => new KeyValuePair<IKey, IValue>(new Binary(p.Key), new Text(p.Value))))
+        {
+        }
+
         /// <summary>
         /// Creates a <see cref="Dictionary"/> instance with key-value
         /// <paramref name="indirectPairs"/>. (Note that only values can be indirect.)

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -56,6 +56,81 @@ namespace Bencodex.Types
         {
         }
 
+        public List(IEnumerable<Boolean> elements)
+            : this(elements.Select(v => (IValue)v))
+        {
+        }
+
+        public List(IEnumerable<Integer> elements)
+            : this(elements.Select(v => (IValue)v))
+        {
+        }
+
+        public List(IEnumerable<Binary> elements)
+            : this(elements.Select(v => (IValue)v))
+        {
+        }
+
+        public List(IEnumerable<Text> elements)
+            : this(elements.Select(v => (IValue)v))
+        {
+        }
+
+        public List(IEnumerable<bool> elements)
+            : this(elements.Select(v => new Boolean(v)))
+        {
+        }
+
+        public List(IEnumerable<short> elements)
+            : this(elements.Select(v => new Integer(v)))
+        {
+        }
+
+        public List(IEnumerable<ushort> elements)
+            : this(elements.Select(v => new Integer(v)))
+        {
+        }
+
+        public List(IEnumerable<int> elements)
+            : this(elements.Select(v => new Integer(v)))
+        {
+        }
+
+        public List(IEnumerable<uint> elements)
+            : this(elements.Select(v => new Integer(v)))
+        {
+        }
+
+        public List(IEnumerable<long> elements)
+            : this(elements.Select(v => new Integer(v)))
+        {
+        }
+
+        public List(IEnumerable<ulong> elements)
+            : this(elements.Select(v => new Integer(v)))
+        {
+        }
+
+        public List(IEnumerable<BigInteger> elements)
+            : this(elements.Select(v => new Integer(v)))
+        {
+        }
+
+        public List(IEnumerable<byte[]> elements)
+            : this(elements.Select(v => new Binary(v)))
+        {
+        }
+
+        public List(IEnumerable<ImmutableArray<byte>> elements)
+            : this(elements.Select(v => new Binary(v)))
+        {
+        }
+
+        public List(IEnumerable<string> elements)
+            : this(elements.Select(v => new Text(v)))
+        {
+        }
+
         /// <summary>
         /// Creates a <see cref="List"/> instance with <paramref name="indirectValues"/> and
         /// a <paramref name="loader"/> used for loading unloaded values.

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -56,76 +56,136 @@ namespace Bencodex.Types
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<Boolean> elements)
             : this(elements.Select(v => (IValue)v))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<Integer> elements)
             : this(elements.Select(v => (IValue)v))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<Binary> elements)
             : this(elements.Select(v => (IValue)v))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<Text> elements)
             : this(elements.Select(v => (IValue)v))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<bool> elements)
             : this(elements.Select(v => new Boolean(v)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<short> elements)
             : this(elements.Select(v => new Integer(v)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<ushort> elements)
             : this(elements.Select(v => new Integer(v)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<int> elements)
             : this(elements.Select(v => new Integer(v)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<uint> elements)
             : this(elements.Select(v => new Integer(v)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<long> elements)
             : this(elements.Select(v => new Integer(v)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<ulong> elements)
             : this(elements.Select(v => new Integer(v)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<BigInteger> elements)
             : this(elements.Select(v => new Integer(v)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<byte[]> elements)
             : this(elements.Select(v => new Binary(v)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<ImmutableArray<byte>> elements)
             : this(elements.Select(v => new Binary(v)))
         {
         }
 
+        /// <summary>
+        /// Creates a <see cref="List"/> instance with <paramref name="elements"/>.
+        /// </summary>
+        /// <param name="elements">The element values to include.</param>
         public List(IEnumerable<string> elements)
             : this(elements.Select(v => new Text(v)))
         {

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,9 +12,19 @@ To be released.
     types.  [[#63]]
  -  `Bencodex.Types.Dictionary.SetItem()` now directly supports `Text`,
     `Beoolean`, `Integer`, `Binary`, `short`, and `ushort` types.  [[#64]]
+ -  `Bencodex.Types.List()` now directly supports `IEnumerable<T>` type
+    parameter where `T` is `Boolean`, `Integer`, `Binary`, `Text`, `bool`,
+    `short`, `ushort`, `int`, `uint`, `long`, `ulong`, `byte[]`,
+    `ImmutableArray<byte>`, or `string`.  [[#65]]
+ -  `Bencodex.Types.List()` now directly supports
+    `IEnumerable<KeyValuePair<K, V>>` type parameter where `K` is `Binary`,
+    `Text`, `byte[]`, `ImmutableArray<byte>`, or `string` and `V` is `Boolean`,
+    `Integer`, `Binary`, `Text`, `bool`, `short`, `ushort`, `int`, `uint`,
+    `long`, `ulong`, `byte[]`, `ImmutableArray<byte>`, or `string`.  [[#65]]
 
 [#63]: https://github.com/planetarium/bencodex.net/pull/63
 [#64]: https://github.com/planetarium/bencodex.net/pull/64
+[#65]: https://github.com/planetarium/bencodex.net/pull/65
 
 
 Version 0.5.0


### PR DESCRIPTION
Still expanding on #58.

`Dictionary` and `List` supports more types directly. Additionally supported types generally mirror that of `Add()`.

- For a `List`, `new List(IEnumerable<T>)` is possible for those `T`s where `Add(T)` is allowed.
- For a `Dictionary`, `new Dictionary(IEnumerable<KeyValuePair<K, V>>)` is possible for those `K` and `V`s where `Add(K, V)` is allowed.

Whereas before we needed something like

```csharp
List<int> intList = new List<int> { 1, 2, 3 };
List list = new List(intList.Select(i => (IValue)(Integer)i));
```

this PR allows

```csharp
List<int> intList = new List<int> { 1, 2, 3 };
List list = new List(intList);
```