### PR TITLE
Drop support for `IEnumerable<IValue>` type parameter

### DIFF
--- a/Bencodex.Benchmarks/ValueBenchmark.cs
+++ b/Bencodex.Benchmarks/ValueBenchmark.cs
@@ -25,7 +25,7 @@ namespace Bencodex.Benchmarks
             .Add("null", Null.Value)
             .Add("int", 1234)
             .Add("dict", Dictionary.Empty.Add("foo", 123).Add("bar", 456))
-            .Add("list", new IValue[] { (Text)"a", (Text)"b", (Text)"c" });
+            .Add("list", new List(new IValue[] { (Text)"a", (Text)"b", (Text)"c" }));
         private static readonly Dictionary _dictCopyA = _dict.Add("z", 1);
         private static readonly Dictionary _dictCopyB = _dict.Add("z", 1);
 

--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -267,14 +267,14 @@ namespace Bencodex.Tests.Types
                 .SetItem("integer", 1337)
                 .SetItem("binary", new byte[] { 0x01, 0x02, 0x03, 0x04 })
                 .SetItem("boolean", true)
-                .SetItem("list", new IValue[] { (Text)"bar", (Integer)1337 });
+                .SetItem("list", new List(new IValue[] { (Text)"bar", (Integer)1337 }));
 
             dictionary = Dictionary.Empty
                 .SetItem((Text)"text", "foo")
                 .SetItem((Text)"integer", 1337)
                 .SetItem((Text)"binary", new byte[] { 0x01, 0x02, 0x03, 0x04 })
                 .SetItem((Text)"boolean", true)
-                .SetItem((Text)"list", new IValue[] { (Text)"bar", (Integer)1337 });
+                .SetItem((Text)"list", new List(new IValue[] { (Text)"bar", (Integer)1337 }));
 
             dictionary = Dictionary.Empty
                 .SetItem("text", (Text)"foo")
@@ -364,7 +364,7 @@ namespace Bencodex.Tests.Types
             string sBooleanKey = "boolean";
             bool sBoolean = true;
             string sListKey = "list";
-            IValue[] sList = new IValue[] { (Text)"bar", (Integer)1337 };
+            List sList = new List(new IValue[] { (Text)"bar", (Integer)1337 });
             byte[] bTextKey = new byte[] { 0x00 };
             string bText = "baz";
             byte[] bShortKey = new byte[] { 0x01 };
@@ -376,7 +376,7 @@ namespace Bencodex.Tests.Types
             byte[] bBooleanKey = new byte[] { 0x04 };
             bool bBoolean = false;
             byte[] bListKey = new byte[] { 0x05 };
-            IValue[] bList = new IValue[] { (Text)"qux", (Integer)2020 };
+            List bList = new List(new IValue[] { (Text)"qux", (Integer)2020 });
 
             // NOTE: Assigned multiple times with the same values for checking syntax.
             var dictionary = Dictionary.Empty
@@ -413,13 +413,13 @@ namespace Bencodex.Tests.Types
                 .Add(sIntKey, (Integer)sInt)
                 .Add(sBinaryKey, (Binary)sBinary)
                 .Add(sBooleanKey, (Bencodex.Types.Boolean)sBoolean)
-                .Add(sListKey, new List(sList))
+                .Add(sListKey, sList)
                 .Add(bTextKey, (Text)bText)
                 .Add(bIntKey, (Integer)bInt)
                 .Add(bShortKey, (Integer)bShort)
                 .Add(bBinaryKey, (Binary)bBinary)
                 .Add(bBooleanKey, (Bencodex.Types.Boolean)bBoolean)
-                .Add(bListKey, new List(bList));
+                .Add(bListKey, bList);
 
             dictionary = Dictionary.Empty
                 .Add((Text)sTextKey, (Text)sText)
@@ -427,13 +427,13 @@ namespace Bencodex.Tests.Types
                 .Add((Text)sIntKey, (Integer)sInt)
                 .Add((Text)sBinaryKey, (Binary)sBinary)
                 .Add((Text)sBooleanKey, (Bencodex.Types.Boolean)sBoolean)
-                .Add((Text)sListKey, new List(sList))
+                .Add((Text)sListKey, sList)
                 .Add((Binary)bTextKey, (Text)bText)
                 .Add((Binary)bIntKey, (Integer)bInt)
                 .Add((Binary)bShortKey, (Integer)bShort)
                 .Add((Binary)bBinaryKey, (Binary)bBinary)
                 .Add((Binary)bBooleanKey, (Bencodex.Types.Boolean)bBoolean)
-                .Add((Binary)bListKey, new List(bList));
+                .Add((Binary)bListKey, bList);
 
             // String keys
             Assert.Equal(sText, (Text)dictionary[sTextKey]);

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -1184,9 +1184,6 @@ namespace Bencodex.Types
         public Dictionary Add(Text key, string value) =>
             Add(key, new Text(value));
 
-        public Dictionary Add(Text key, IEnumerable<IValue> value) =>
-            Add(key, new List(value));
-
         public Dictionary Add(Binary key, IValue value) =>
             (Dictionary)Add((IKey)key, value);
 
@@ -1240,9 +1237,6 @@ namespace Bencodex.Types
 
         public Dictionary Add(Binary key, string value) =>
             Add(key, new Text(value));
-
-        public Dictionary Add(Binary key, IEnumerable<IValue> value) =>
-            Add(key, new List(value));
 
         public Dictionary Add(string key, IValue value) =>
             Add(new Text(key), value);
@@ -1298,9 +1292,6 @@ namespace Bencodex.Types
         public Dictionary Add(string key, string value) =>
             Add(key, new Text(value));
 
-        public Dictionary Add(string key, IEnumerable<IValue> value) =>
-            Add(key, new List(value));
-
         public Dictionary Add(ImmutableArray<byte> key, IValue value) =>
             Add(new Binary(key), value);
 
@@ -1355,9 +1346,6 @@ namespace Bencodex.Types
         public Dictionary Add(ImmutableArray<byte> key, string value) =>
             Add(key, new Text(value));
 
-        public Dictionary Add(ImmutableArray<byte> key, IEnumerable<IValue> value) =>
-            Add(key, new List(value));
-
         public Dictionary Add(byte[] key, IValue value) =>
             Add(new Binary(key), value);
 
@@ -1411,9 +1399,6 @@ namespace Bencodex.Types
 
         public Dictionary Add(byte[] key, string value) =>
             Add(key, new Text(value));
-
-        public Dictionary Add(byte[] key, IEnumerable<IValue> value) =>
-            Add(key, new List(value));
 
         /// <inheritdoc cref="IImmutableDictionary{TKey,TValue}.AddRange"/>
         public IImmutableDictionary<IKey, IValue> AddRange(
@@ -1495,9 +1480,6 @@ namespace Bencodex.Types
         public Dictionary SetItem(Text key, string value) =>
             SetItem(key, new Text(value));
 
-        public Dictionary SetItem(Text key, IEnumerable<IValue> value) =>
-            SetItem(key, new List(value));
-
         public Dictionary SetItem(Binary key, IValue value) =>
             (Dictionary)SetItem((IKey)key, value);
 
@@ -1551,9 +1533,6 @@ namespace Bencodex.Types
 
         public Dictionary SetItem(Binary key, string value) =>
             SetItem(key, new Text(value));
-
-        public Dictionary SetItem(Binary key, IEnumerable<IValue> value) =>
-            SetItem(key, new List(value));
 
         public Dictionary SetItem(string key, IValue value) =>
             SetItem(new Text(key), value);
@@ -1609,9 +1588,6 @@ namespace Bencodex.Types
         public Dictionary SetItem(string key, string value) =>
             SetItem(key, new Text(value));
 
-        public Dictionary SetItem(string key, IEnumerable<IValue> value) =>
-            SetItem(key, new List(value));
-
         public Dictionary SetItem(ImmutableArray<byte> key, IValue value) =>
             SetItem(new Binary(key), value);
 
@@ -1666,9 +1642,6 @@ namespace Bencodex.Types
         public Dictionary SetItem(ImmutableArray<byte> key, string value) =>
             SetItem(key, new Text(value));
 
-        public Dictionary SetItem(ImmutableArray<byte> key, IEnumerable<IValue> value) =>
-            SetItem(key, new List(value));
-
         public Dictionary SetItem(byte[] key, IValue value) =>
             SetItem(new Binary(key), value);
 
@@ -1722,9 +1695,6 @@ namespace Bencodex.Types
 
         public Dictionary SetItem(byte[] key, string value) =>
             SetItem(key, new Text(value));
-
-        public Dictionary SetItem(byte[] key, IEnumerable<IValue> value) =>
-            SetItem(key, new List(value));
 
         /// <inheritdoc cref="IImmutableDictionary{TKey,TValue}.SetItems"/>
         public IImmutableDictionary<IKey, IValue> SetItems(

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,10 +21,13 @@ To be released.
     `Text`, `byte[]`, `ImmutableArray<byte>`, or `string` and `V` is `Boolean`,
     `Integer`, `Binary`, `Text`, `bool`, `short`, `ushort`, `int`, `uint`,
     `long`, `ulong`, `byte[]`, `ImmutableArray<byte>`, or `string`.  [[#65]]
+ -  `Bencodex.Types.Dictionary.Add()` and `Bencodex.Types.Dictionary.SetItem()`
+    no longer support `IEnumerable<IValue>` type parameter.  [[#66]]
 
 [#63]: https://github.com/planetarium/bencodex.net/pull/63
 [#64]: https://github.com/planetarium/bencodex.net/pull/64
 [#65]: https://github.com/planetarium/bencodex.net/pull/65
+[#66]: https://github.com/planetarium/bencodex.net/pull/66
 
 
 Version 0.5.0


### PR DESCRIPTION
Other than creating a new `List`, I don't think `IEnumerable<IValue>` is "primitive" enough to have its type supported for `Add()` and `SetItem()`. 🙄