### PR TITLE
Introduce `IBencodable` interface

### DIFF
--- a/Bencodex/IBencodable.cs
+++ b/Bencodex/IBencodable.cs
@@ -42,6 +42,8 @@ namespace Bencodex
     ///
     ///     public int Y { get; }
     ///
+    ///     public IValue Bencoded => List.Empty.Add(X).Add(Y);
+    ///
     ///     public static Point Decode(IValue bencoded)
     ///     {
     ///         return bencoded is List list
@@ -74,6 +76,6 @@ namespace Bencodex
         /// </para>
         /// </remarks>
         [Pure]
-        public IValue Bencoded { get; }
+        IValue Bencoded { get; }
     }
 }

--- a/Bencodex/IBencodable.cs
+++ b/Bencodex/IBencodable.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Diagnostics.Contracts;
+using Bencodex.Types;
+
+namespace Bencodex
+{
+    /// <summary>
+    /// Defines a generic <see langword="interface"/> for an object that can be
+    /// encoded into an <see cref="IValue"/>.  Any <see langword="class"/> implementing
+    /// this <see langword="interface"/> should also implement either a constructor
+    /// or a <see langword="static"/> factory method with an <see cref="IValue"/> as a parameter
+    /// for decoding.
+    /// </summary>
+    /// <remarks>
+    /// Note that encoding and decoding mentioned here are different from
+    /// <see cref="Codec.Encode(IValue)"/> and <see cref="Codec.Decode(byte[])"/>.
+    /// </remarks>
+    /// <example>
+    /// The following example shows an implementation of an integer point <see langword="class"/>
+    /// with two distinct methods of decoding, via a constructor and a <see langword="static"/>
+    /// factory method, for illustration:
+    /// <code><![CDATA[
+    /// public class Point : IBencodable
+    /// {
+    ///     public Point(int x, int y)
+    ///     {
+    ///         X = x;
+    ///         Y = y;
+    ///     }
+    ///
+    ///     public Point(IValue bencoded)
+    ///         : this((List)bencoded)
+    ///     {
+    ///     }
+    ///
+    ///     private Point(List bencoded)
+    ///         : this((Integer)bencoded[0], (Integer)bencoded[1])
+    ///     {
+    ///     }
+    ///
+    ///     public int X { get; }
+    ///
+    ///     public int Y { get; }
+    ///
+    ///     public static Point Decode(IValue bencoded)
+    ///     {
+    ///         return bencoded is List list
+    ///             ? new Point((Integer)list[0], (Integer)list[1])
+    ///             : throw new ArgumentException(
+    ///                 $"Invalid type: {bencoded.GetType()}",
+    ///                 nameof(bencoded));
+    ///     }
+    /// }
+    /// ]]></code>
+    /// </example>
+    public interface IBencodable
+    {
+        /// <summary>
+        /// An <see cref="IValue"/> representation of this object that can be
+        /// decoded back to instantiate an equal object.  The decoded object must
+        /// be equal to the original in the sense that <see cref="IEquatable{T}.Equals(T)"/>
+        /// should be <see langword="true"/>.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Note that the only requirement is that the produced <see cref="IValue"/>
+        /// can be decoded back to an equal object.  This representation may not be canonical
+        /// in the sense that additional junk data may be present in an <see cref="IValue"/>
+        /// that one may wish to decode and this may be discarded while decoding.
+        /// </para>
+        /// <para>
+        /// A specific implemnetation may decide to only allow the canonical representation
+        /// to be decoded.
+        /// </para>
+        /// </remarks>
+        [Pure]
+        public IValue Bencoded { get; }
+    }
+}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Version 0.8.0
 
 To be released.
 
+ -  Added `IBencodable` interface.  [[#73]]
+
+[#73]: https://github.com/planetarium/bencodex.net/pull/73
+
 
 Version 0.7.0
 -------------


### PR DESCRIPTION
This is an attempt to prevent further fragmentation. This tries to address the following issues:
- Although the [bencodex.net] library is being used pretty heavily across the board, it isn't apparent from `class` or `struct` descriptor that such and such can be encoded to an `IValue`. It is only by usage and API that a certain `class` or `struct` can be encoded to an `IValue`.
- As there is no contract, the implementation for encoding and decoding between different `class`es differ wildly. In my opinion, users generally should not care about the underlying concrete type for the encoded `IValue`. That is, it should not be the user's responsibility to always know whether some piece of data as a generic `IValue` retrieved from some database should be a `List` or a `Dictionary` before instantiating a desired object.

I'm still not sure about the naming tho. 🙄
Other candidate was `IBencodexable` with `Bencodexed` property, but this felt a bit too forced.
I don't think there is much danger in confusion with the original [bencoding].

[bencodex.net]: https://github.com/planetarium/bencodex.net
[bencoding]: https://en.wikipedia.org/wiki/Bencode