### PR TITLE
Fix `getHashCode()` to be consistent

### DIFF
--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using Bencodex.Misc;
 using Bencodex.Types;
+using SharpYaml.Tokens;
 using Xunit;
 using static Bencodex.Misc.ImmutableByteArrayExtensions;
 using static Bencodex.Tests.TestUtils;
@@ -806,6 +807,27 @@ namespace Bencodex.Tests.Types
             }
 
             Assert.Empty(_loadLog);
+        }
+
+        [Fact]
+        public void HashCode()
+        {
+            Assert.Equal(
+                _textKey.GetHashCode(),
+                Dictionary.Empty.SetItem("foo", "bar").GetHashCode());
+            Assert.Equal(
+                _binaryKey.GetHashCode(),
+                Dictionary.Empty.SetItem(Encoding.ASCII.GetBytes("foo"), "bar").GetHashCode());
+            Assert.Equal(
+                _mixedKeys.GetHashCode(),
+                Dictionary.Empty
+                    .Add("stringKey", "string")
+                    .Add(new byte[] { 0x00 }, "byte").GetHashCode());
+
+            var added = _mixedKeys.Add("baz", "qux");
+            Assert.NotEqual(_mixedKeys.GetHashCode(), added.GetHashCode());
+            Assert.Equal(added.GetHashCode(), _mixedKeys.Add("baz", "qux").GetHashCode());
+            Assert.Equal(_mixedKeys.GetHashCode(), added.Remove(new Text("baz")).GetHashCode());
         }
 
         private IValue Loader(Fingerprint f)

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -456,6 +456,28 @@ namespace Bencodex.Tests.Types
             Assert.Empty(_loadLog);
         }
 
+        [Fact]
+        public void HashCode()
+        {
+            Assert.Equal(
+                _zero.GetHashCode(),
+                List.Empty.GetHashCode());
+            Assert.Equal(
+                _one.GetHashCode(),
+                new List(Null.Value).GetHashCode());
+            Assert.Equal(
+                _two.GetHashCode(),
+                new List(new Text[] { "hello", "world" }.Cast<IValue>()).GetHashCode());
+            Assert.Equal(
+                _nest.GetHashCode(),
+                new List(Null.Value, _zero, _one, _two).GetHashCode());
+
+            var added = _nest.Add("baz");
+            Assert.NotEqual(_nest.GetHashCode(), added.GetHashCode());
+            Assert.Equal(added.GetHashCode(), _nest.Add("baz").GetHashCode());
+            Assert.Equal(_nest.GetHashCode(), added.Remove(new Text("baz")).GetHashCode());
+        }
+
         private IValue Loader(Fingerprint f)
         {
             _loadLog.Add(f);

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -1774,7 +1774,9 @@ namespace Bencodex.Types
             ((IEquatable<IImmutableDictionary<IKey, IValue>>)this).Equals(o);
 
         /// <inheritdoc cref="object.GetHashCode()"/>
-        public override int GetHashCode() => _dict.GetHashCode();
+        public override int GetHashCode()
+            => unchecked(_dict.Aggregate(GetType().GetHashCode(), (accum, next)
+                => (accum * 397) ^ ((next.Key.GetHashCode() * 397) ^ next.Value.GetHashCode())));
 
         /// <inheritdoc cref="IValue.Inspect(bool)"/>
         public string Inspect(bool loadAll)

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -336,8 +336,9 @@ namespace Bencodex.Types
             ((IEquatable<IImmutableList<IValue>>)this).Equals(other);
 
         /// <inheritdoc cref="object.GetHashCode()"/>
-        public override int GetHashCode() =>
-            _values.GetHashCode();
+        public override int GetHashCode()
+            => unchecked(_values.Aggregate(GetType().GetHashCode(), (accum, next)
+                => (accum * 397) ^ next.GetHashCode()));
 
         IEnumerator IEnumerable.GetEnumerator() =>
             ((IEnumerable<IValue>)this).GetEnumerator();

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Version 0.9.0
 
 To be released.
 
+ -  Fixed `Bencodex.Types.Dictionary.GetHashCode()` to return consistent hashcode.  [[#76]]
+ -  Fixed `Bencodex.Types.List.GetHashCode()` to return consistent hashcode.  [[#76]]
+
+[#76]: https://github.com/planetarium/bencodex.net/pull/76
+
 
 Version 0.8.0
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,9 +6,12 @@ Version 0.9.0
 
 To be released.
 
- -  Fixed `Bencodex.Types.Dictionary.GetHashCode()` to return consistent hashcode.  [[#76]]
- -  Fixed `Bencodex.Types.List.GetHashCode()` to return consistent hashcode.  [[#76]]
+ -  Fixed `Bencodex.Types.Dictionary.GetHashCode()` to return hash code derived
+    from its content.  [[#72], [#76]]
+ -  Fixed `Bencodex.Types.List.GetHashCode()` to return hash code derived from
+    its content.  [[#72], [#76]]
 
+[#72]: https://github.com/planetarium/bencodex.net/issues/72
 [#76]: https://github.com/planetarium/bencodex.net/pull/76
 
 


### PR DESCRIPTION
### Changes
- Fixed `Bencodex.Types.Dictionary.GetHashCode()` to return consistent hashcode.
- Fixed `Bencodex.Types.List.GetHashCode()` to return consistent hashcode.

Applied `FNV-1 hash`, using `GetType().GetHashCode()` as `FNV_offset_basis`, and `397` as `FNV_prime`.

### Related issue
- https://github.com/planetarium/bencodex.net/issues/72