### PR TITLE
Implement `IndirectValue.GetHashCode()`

### DIFF
--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -828,6 +828,11 @@ namespace Bencodex.Tests.Types
             Assert.NotEqual(_mixedKeys.GetHashCode(), added.GetHashCode());
             Assert.Equal(added.GetHashCode(), _mixedKeys.Add("baz", "qux").GetHashCode());
             Assert.Equal(_mixedKeys.GetHashCode(), added.Remove(new Text("baz")).GetHashCode());
+
+            Assert.NotEqual(
+                Dictionary.Empty.Add("type_id", 0).Add("values", List.Empty).GetHashCode(),
+                Dictionary.Empty.Add("type_id", 1).Add("values", "foo").GetHashCode()
+            );
         }
 
         private IValue Loader(Fingerprint f)

--- a/Bencodex.Tests/Types/IndirectValueTest.cs
+++ b/Bencodex.Tests/Types/IndirectValueTest.cs
@@ -106,5 +106,11 @@ namespace Bencodex.Tests.Types
             Assert.Throws<ArgumentNullException>(() => _default.GetValue(null));
             Assert.Null(_default.LoadedValue);
         }
+
+        [Fact]
+        public void HashCode()
+        {
+            Assert.NotEqual(new IndirectValue((Integer)1), new IndirectValue((Integer)0));
+        }
     }
 }

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -476,6 +476,12 @@ namespace Bencodex.Tests.Types
             Assert.NotEqual(_nest.GetHashCode(), added.GetHashCode());
             Assert.Equal(added.GetHashCode(), _nest.Add("baz").GetHashCode());
             Assert.Equal(_nest.GetHashCode(), added.Remove(new Text("baz")).GetHashCode());
+
+            // Same length but different contents.
+            Assert.NotEqual(
+                new List((Integer)0, Null.Value, (Integer)2).GetHashCode(),
+                new List(Null.Value, (Text)"FOO", Dictionary.Empty).GetHashCode()
+            );
         }
 
         private IValue Loader(Fingerprint f)

--- a/Bencodex/Types/IndirectValue.cs
+++ b/Bencodex/Types/IndirectValue.cs
@@ -113,5 +113,7 @@ namespace Bencodex.Types
 
             return v;
         }
+
+        public override int GetHashCode() => Fingerprint.GetHashCode();
     }
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ Version 0.10.0
 
 To be released.
 
+ -  Fixed `Bencodex.Types.IndirectValue.GetHashCode()` to return hash code derived
+    from its content.  [[#79]]
+
+
+[#79]: https://github.com/planetarium/bencodex.net/pull/79
 
 Version 0.9.0
 -------------


### PR DESCRIPTION
Previously, if there are two dictionaries like the below examples, their hashcode was the same. Because `Dictionary` has its key-value pairs as `KeyValuePair<IKey, IndirectValue>` type and `new IndirectValue((Integer)0).GetHashCode()` was the same with `new IndirectValue((Integer)1).GetHashCode()`

```
{ "type_id": 0 }
{ "type_id": 1 }
```