### PR TITLE
⚡ Optimized `Encoder.EncodeDigits()`

### DIFF
--- a/Bencodex/Encoder.cs
+++ b/Bencodex/Encoder.cs
@@ -286,27 +286,42 @@ namespace Bencodex
             return 2L + lenStrLength + fingerprint.SerializeInto(buffer, offset);
         }
 
-        internal static long CountDecimalDigits(long value) => value < 10L
-            ? 1L
-            : value < 100L
-                ? 2L
-                : value < 1000L
-                    ? 3L
-                    : value < 10000L
-                        ? 4L
-                        : (long)Math.Floor(Math.Log10(value)) + 1L;
+        internal static long CountDecimalDigits(long value)
+        {
+#pragma warning disable SA1503 // Braces should not be omitted
+            if (value < 10L) return 1;
+            if (value < 100L) return 2;
+            if (value < 1000L) return 3;
+            if (value < 10000L) return 4;
+            if (value < 100000L) return 5;
+            if (value < 1000000L) return 6;
+            if (value < 10000000L) return 7;
+            if (value < 100000000L) return 8;
+            if (value < 1000000000L) return 9;
+            if (value < 10000000000L) return 10;
+            if (value < 100000000000L) return 11;
+            if (value < 1000000000000L) return 12;
+            if (value < 10000000000000L) return 13;
+            if (value < 100000000000000L) return 14;
+            if (value < 1000000000000000L) return 15;
+            if (value < 10000000000000000L) return 16;
+            if (value < 100000000000000000L) return 17;
+            if (value < 1000000000000000000L) return 18;
+            return 19;
+#pragma warning restore SA1503
+        }
 
         internal static long EncodeDigits(long positiveInt, byte[] buffer, long offset)
         {
-            string digits = positiveInt.ToString(CultureInfo.InvariantCulture);
-            if (offset < int.MaxValue)
+            const int asciiZero = 0x30; // '0'
+            long length = CountDecimalDigits(positiveInt);
+            for (long i = offset + length - 1; i >= offset; i--)
             {
-                return Encoding.ASCII.GetBytes(digits, 0, digits.Length, buffer, (int)offset);
+                buffer[i] = (byte)(positiveInt % 10 + asciiZero);
+                positiveInt /= 10;
             }
 
-            byte[] ascii = Encoding.ASCII.GetBytes(digits);
-            Array.Copy(ascii, 0L, buffer, offset, ascii.LongLength);
-            return ascii.Length;
+            return length;
         }
 
         // TODO: Needs a unit test.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Version 0.11.0
 
 To be released.
 
+ -  Slightly optimized encoding both for speed and memory.  [[#83]]
+
+[#83]: https://github.com/planetarium/bencodex.net/pull/83
+
 
 Version 0.10.0
 --------------


### PR DESCRIPTION
Tested with 1,000,000 `long`s. Hot path for `Binary`, `Text` encoding.
Neither requires string conversion nor additional memory allocation. 😗

As for `Encoder.EncodeInteger()`, conversion from `BigInteger` to `long` seems heaver than `ToString()`, so it is left as it is. 😕

BenchmarkDotNet=v0.13.2, OS=Windows 10 (10.0.19045.3086)
11th Gen Intel Core i7-1185G7 3.00GHz, 1 CPU, 8 logical and 4 physical cores
.NET SDK=7.0.203
  [Host]     : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT AVX2
  DefaultJob : .NET 6.0.5 (6.0.522.21309), X64 RyuJIT AVX2


|   Method |     Mean |    Error |   StdDev |       Gen0 | Allocated |
|--------- |---------:|---------:|---------:|-----------:|----------:|
| GetBytes | 64.25 ms | 1.320 ms | 3.786 ms | 17800.0000 | 110.53 MB |
|  ForLoop | 42.02 ms | 0.840 ms | 2.396 ms |          - |   3.81 MB |