### PR TITLE
⚡ Optimized `Decoder`

### DIFF
--- a/Bencodex/Decoder.cs
+++ b/Bencodex/Decoder.cs
@@ -67,7 +67,7 @@ namespace Bencodex
                     return new Bencodex.Types.Boolean(false);
 
                 case 0x69: // 'i'
-                    BigInteger integer = ReadDigits(true, e, BigInteger.Parse);
+                    BigInteger integer = ReadDigits(e, BigInteger.Parse);
                     return new Integer(integer);
 
                 case 0x75: // 'u'
@@ -318,7 +318,7 @@ namespace Bencodex
             return length;
         }
 
-        private byte[] ReadDigits(bool takeMinusSign, byte delimiter)
+        private byte[] ReadDigits(byte delimiter)
         {
             const int defaultBufferSize = 10;
             byte[] buffer = new byte[defaultBufferSize];
@@ -327,15 +327,14 @@ namespace Bencodex
 
             if (b is null)
             {
-                const string minusSignOr = "a minus sign or ";
                 throw new DecodingException(
-                    $"Expected {(takeMinusSign ? minusSignOr : string.Empty)}digits, " +
+                    $"Expected a minus sign or a digit, " +
                     $"but the byte stream terminates at {_offset}."
                 );
             }
 
             bool minus = false;
-            if (takeMinusSign && b == 0x2d) // '-'
+            if (b == 0x2d) // '-'
             {
                 minus = true;
                 b = ReadByte();
@@ -396,12 +395,11 @@ namespace Bencodex
         }
 
         private T ReadDigits<T>(
-            bool takeMinusSign,
             byte delimiter,
             Func<string, IFormatProvider, T> converter
         )
         {
-            byte[] buffer = ReadDigits(takeMinusSign, delimiter);
+            byte[] buffer = ReadDigits(delimiter);
             var digits = new char[buffer.Length];
             for (int i = 0; i < buffer.Length; i++)
             {

--- a/Bencodex/Decoder.cs
+++ b/Bencodex/Decoder.cs
@@ -302,7 +302,7 @@ namespace Bencodex
 #pragma warning restore SA1131
                 {
                     throw new ArgumentException(
-                        $"Expected a digit (0x30-0x40), but got 0x{lastByte:x} at {_offset}."
+                        $"Expected a digit (0x30-0x39), but got 0x{lastByte:x} at {_offset}."
                     );
                 }
 
@@ -366,10 +366,10 @@ namespace Bencodex
             while (lastByte != delimiter)
             {
 #pragma warning disable SA1131
-                if (!(0x30 <= lastByte && lastByte < 0x40)) // not '0'-'9'
+                if (lastByte < 0x30 || 0x39 < lastByte) // not '0'-'9'
                 {
                     throw new DecodingException(
-                        $"Expected a digit (0x30-0x40), but got 0x{lastByte:x} at {_offset}."
+                        $"Expected a digit (0x30-0x39), but got 0x{lastByte:x} at {_offset}."
                     );
                 }
 #pragma warning restore SA1131

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Version 0.12.0
 
 To be released.
 
+ -  Slightly optimized decoding both for speed and memory.  [[#86]]
+
+[#86]: https://github.com/planetarium/bencodex.net/pull/86
+
 
 Version 0.11.0
 --------------


### PR DESCRIPTION
Companion PR to #83. Tested with 1,000,000 random `long`s up to 1024 (since for most cases, byte string and unicode string legths will be skewed towards the lower end).
Again, only deals with the length portion of byte strings and unicode strings.

|       Method |      Mean |     Error |    StdDev |       Gen0 |  Allocated |
|------------- |----------:|----------:|----------:|-----------:|-----------:|
|   ToLongAtoi | 20.875 ms | 0.4165 ms | 1.0898 ms | 11468.7500 | 72000015 B |
| ToLongDirect |  6.223 ms | 0.1236 ms | 0.2608 ms |          - |        4 B |
