### PR TITLE
⚡ Optimize decoding with less backtracking

### DIFF
--- a/Bencodex/Decoder.cs
+++ b/Bencodex/Decoder.cs
@@ -29,15 +29,13 @@ namespace Bencodex
         public IValue Decode()
         {
             IValue value = DecodeValue() ??
-                throw new DecodingException($"Failed to decode stream");
-
-            if (!EndOfStream())
-            {
                 throw new DecodingException(
-                    $"An unexpected trailing byte remain at {_offset}.");
-            }
+                    $"An unexpected token byte 0x{0x65:x} at {_offset - 1}");
 
-            return value;
+            return EndOfStream()
+                ? value
+                : throw new DecodingException(
+                    $"An unexpected trailing byte remains at {_offset}.");
         }
 
         private IValue? DecodeValue()
@@ -81,7 +79,8 @@ namespace Bencodex
                     while (DecodeKey() is IKey key)
                     {
                         IValue value = DecodeValue()
-                            ?? throw new DecodingException("Failed to decode");
+                            ?? throw new DecodingException(
+                                $"An unexpected token byte 0x{0x65:x} at {_offset - 1}");
                         pairs.Add(new KeyValuePair<IKey, IValue>(key, value));
                     }
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,8 +12,10 @@ To be released.
  -  Removed `IndirectValue` class.  [[#91]]
  -  Changed `Codec.Encode()` and `Codec.Decode()` to no longer accept
     `IOffloadOptions` as an argument.  [[#91]]
+ -  Optimized for faster decoding on encoded `List`s and `Dictionary`s.  [[#93]]
 
 [#91]: https://github.com/planetarium/bencodex.net/pull/91
+[#93]: https://github.com/planetarium/bencodex.net/pull/93
 
 
 Version 0.12.0


### PR DESCRIPTION
Incorporates two following components:

- Less backtracking by avoiding peeking when it isn't necessary
- Returning `byte` instead of `byte?` for `ReadByte()` used for peeking.

## Decoding benchmark

Tested with data size of 10,000. Nested means one additional layer. For example, nested list would be a `List` of size `SetSize` with each element also being a `List` of size `SetSize`. Endpoints were randomized to be either `Binary` or `Text`.

Memory save is mostly from #91. Improves speed by roughly 20% on `List`s and `Dictionary`s.

### 0.12.0

|           Method | SetSize | WordSize |        Mean |     Error |    StdDev |  Allocated |
|----------------- |-------- |--------- |------------:|----------:|----------:|-----------:|
|       DecodeList |      10 |       10 |    16.33 ms |  0.939 ms |  1.005 ms |   33.26 MB |
|       DecodeDict |      10 |       10 |    53.58 ms |  3.509 ms |  4.041 ms |   73.69 MB |
| DecodeNestedList |      10 |       10 |   163.18 ms |  8.270 ms |  9.524 ms |  336.54 MB |
| DecodeNestedDict |      10 |       10 |   574.93 ms | 24.271 ms | 27.951 ms |  781.33 MB |

### Updated

|           Method | SetSize | WordSize |        Mean |     Error |    StdDev |  Allocated |
|----------------- |-------- |--------- |------------:|----------:|----------:|-----------:|
|       DecodeList |      10 |       10 |    11.97 ms |  0.747 ms |  0.830 ms |   21.52 MB |
|       DecodeDict |      10 |       10 |    42.57 ms |  4.061 ms |  4.514 ms |   56.82 MB |
| DecodeNestedList |      10 |       10 |   123.50 ms | 10.638 ms | 11.824 ms |  208.04 MB |
| DecodeNestedDict |      10 |       10 |   439.78 ms | 23.726 ms | 27.323 ms |  596.64 MB |
