### PR TITLE
🐛 ⚡ Fixed invalid decoding of dictionaries

### DIFF
--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -677,6 +677,20 @@ namespace Bencodex.Tests.Types
         }
 
         [Fact]
+        public void EncodedMustBeOrdered()
+        {
+            Codec codec = new Codec();
+            string valid = "d3:bar4:spam3:fooi42ee";
+            string invalid = "d3:fooi42e3:bar4:spame";
+            byte[] validEncoded = Encoding.ASCII.GetBytes(valid);
+            byte[] invalidEncoded = Encoding.ASCII.GetBytes(invalid);
+
+            IValue decoded = codec.Decode(validEncoded);
+            Assert.IsType<Dictionary>(decoded);
+            Assert.Throws<DecodingException>(() => codec.Decode(invalidEncoded));
+        }
+
+        [Fact]
         public void HashCode()
         {
             Assert.Equal(

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -905,6 +905,12 @@ namespace Bencodex.Types
 
         internal Dictionary(in ImmutableSortedDictionary<IKey, IValue> dict)
         {
+            if (!KeyComparer.Instance.Equals(dict.KeyComparer))
+            {
+                throw new ArgumentException(
+                    $"Given {nameof(dict)} has an invalid key comparer.");
+            }
+
             _dict = dict;
         }
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,9 +13,14 @@ To be released.
  -  Changed `Codec.Encode()` and `Codec.Decode()` to no longer accept
     `IOffloadOptions` as an argument.  [[#91]]
  -  Optimized for faster decoding on encoded `List`s and `Dictionary`s.  [[#93]]
+ -  Fixed a bug where a wrongly encoded `byte[]` could be decoded
+    into a `Dictionary`.  [[#92], [#94]]
+ -  Optimized decoding `Dictionary`'s both for speed and memory.  [[#94]]
 
 [#91]: https://github.com/planetarium/bencodex.net/pull/91
+[#92]: https://github.com/planetarium/bencodex.net/issues/92
 [#93]: https://github.com/planetarium/bencodex.net/pull/93
+[#94]: https://github.com/planetarium/bencodex.net/pull/94
 
 
 Version 0.12.0


### PR DESCRIPTION
Resolves #92.

As a nice side-effect, this also optimizes decoding dictionaries.

If we already have wrongly encoded dictionary written into the network, this can be catastrophic. 🙄

## Decoding benchmark results

The testing environment is as usual.

### Previous

|           Method | SetSize | WordSize |        Mean |     Error |    StdDev |  Allocated |
|----------------- |-------- |--------- |------------:|----------:|----------:|-----------:|
|       DecodeDict |      10 |       10 |    42.57 ms |  4.061 ms |  4.514 ms |   56.82 MB |
| DecodeNestedDict |      10 |       10 |   439.78 ms | 23.726 ms | 27.323 ms |  596.64 MB |
|       DecodeDict |      20 |       10 |    85.96 ms |  5.403 ms |  6.222 ms |  105.61 MB |
| DecodeNestedDict |      20 |       10 | 1,777.23 ms | 51.972 ms | 57.767 ms | 2160.26 MB |

### Updated

|           Method | SetSize | WordSize |        Mean |     Error |    StdDev | Allocated |
|----------------- |-------- |--------- |------------:|----------:|----------:|----------:|
|       DecodeDict |      10 |       10 |    32.81 ms |  2.064 ms |  2.294 ms |  39.92 MB |
| DecodeNestedDict |      10 |       10 |   355.73 ms | 29.787 ms | 31.872 ms |  410.3 MB |
|       DecodeDict |      20 |       10 |    68.72 ms |  4.795 ms |  5.522 ms |  76.55 MB |
| DecodeNestedDict |      20 |       10 | 1,581.54 ms | 60.483 ms | 69.652 ms | 1549.7 MB |
