### PR TITLE
⚡ 🐛 Fix `Integer` decoding bug and optimize

### DIFF
--- a/Bencodex.Tests/Types/IntegerTest.cs
+++ b/Bencodex.Tests/Types/IntegerTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Globalization;
 using System.Numerics;
+using System.Text;
 using Bencodex.Types;
 using Xunit;
 using static Bencodex.Misc.ImmutableByteArrayExtensions;
@@ -112,6 +113,21 @@ namespace Bencodex.Tests.Types
                     new Integer(n).CountDecimalDigits()
                 );
             }
+        }
+
+        [Fact]
+        public void InvalidFormats()
+        {
+            Codec codec = new Codec();
+            byte[] case1 = Encoding.ASCII.GetBytes("ie");
+            byte[] case2 = Encoding.ASCII.GetBytes("i+142e");
+            byte[] case3 = Encoding.ASCII.GetBytes("i00e");
+            byte[] case4 = Encoding.ASCII.GetBytes("i-0e");
+
+            Assert.Throws<DecodingException>(() => codec.Decode(case1));
+            Assert.Throws<DecodingException>(() => codec.Decode(case2));
+            Assert.Throws<DecodingException>(() => codec.Decode(case3));
+            Assert.Throws<DecodingException>(() => codec.Decode(case4));
         }
 
         private void IntegerGeneric(Func<int, Integer?> convert)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.14.0
 
 To be released.
 
+ -  Fixed a bug where a wrongly encoded `byte[]` could be decoded into
+    an `Integer`.  [[#97]]
+ -  Optimized decoding `Integer`s both for speed and memory.  [[#97]]
+
+[#97]: https://github.com/planetarium/bencodex.net/pull/97
+
 
 Version 0.13.0
 --------------


### PR DESCRIPTION
In terms of performance, improvements are pretty minor. 🙄
However, there were bugs regarding decoding where invalid formats were allowed.  See the newly added test.
Cases 1, 3, and 4 fail on 0.13.0.

# Benchmark results

Tested with 100,000 encoded `Integer`s. `DecodeSmall` was generated using `Random.Next()` and `DecodeBig` was generated using `Random.NextInt64()`.

## 0.13.0

|      Method |     Mean |    Error |   StdDev |       Gen0 | Allocated |
|------------ |---------:|---------:|---------:|-----------:|----------:|
| DecodeSmall | 30.88 ms | 0.603 ms | 0.922 ms |  8500.0000 |  50.86 MB |
|   DecodeBig | 50.19 ms | 0.485 ms | 0.405 ms | 11500.0000 |  70.18 MB |

## Updated

|      Method |     Mean |    Error |   StdDev |      Gen0 | Allocated |
|------------ |---------:|---------:|---------:|----------:|----------:|
| DecodeSmall | 26.09 ms | 1.067 ms | 1.897 ms | 5500.0000 |  33.98 MB |
|   DecodeBig | 46.98 ms | 0.912 ms | 1.420 ms | 8750.0000 |   53.4 MB |