### PR TITLE
⚡ Completely remove back tracking

### DIFF
--- a/Bencodex/Decoder.cs
+++ b/Bencodex/Decoder.cs
@@ -92,20 +92,8 @@ namespace Bencodex
 
                     return new Dictionary(builder.ToImmutable());
 
-                case 0x30: // '0'
-                case 0x31: // '1'
-                case 0x32: // '2'
-                case 0x33: // '3'
-                case 0x34: // '4'
-                case 0x35: // '5'
-                case 0x36: // '6'
-                case 0x37: // '7'
-                case 0x38: // '8'
-                case 0x39: // '9'
+                default:
                     return ReadBinary();
-
-                case { } b:
-                    throw new DecodingException($"An unexpected byte 0x{b:x} at {_offset - 1}.");
             }
         }
 
@@ -119,23 +107,8 @@ namespace Bencodex
                 case 0x75: // 'u':
                     return ReadTextAfterPrefix();
 
-                case 0x30: // '0'
-                case 0x31: // '1'
-                case 0x32: // '2'
-                case 0x33: // '3'
-                case 0x34: // '4'
-                case 0x35: // '5'
-                case 0x36: // '6'
-                case 0x37: // '7'
-                case 0x38: // '8'
-                case 0x39: // '9'
+                default:
                     return ReadBinary();
-
-                case { } b:
-                    throw new DecodingException(
-                        $"Expected a dictionary key, but got an unexpected byte 0x{b:x} at " +
-                        $"{_offset - 1}."
-                    );
             }
         }
 
@@ -316,18 +289,15 @@ namespace Bencodex
             byte[] buffer = new byte[length];
             Read(buffer);
 
-            string textContent;
             try
             {
-                textContent = Encoding.UTF8.GetString(buffer);
+                return new Text(Encoding.UTF8.GetString(buffer));
             }
             catch (ArgumentException e)
             {
                 throw new DecodingException(
                     $"Failed to decode {nameof(Text)} starting from {start}.", e);
             }
-
-            return new Text(textContent);
         }
     }
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,8 +9,10 @@ To be released.
  -  Fixed a bug where a wrongly encoded `byte[]` could be decoded into
     an `Integer`.  [[#97]]
  -  Optimized decoding `Integer`s both for speed and memory.  [[#97]]
+ -  Optimized for faster decoding on encoded `List`s and `Dictionary`s.  [[#98]]
 
 [#97]: https://github.com/planetarium/bencodex.net/pull/97
+[#98]: https://github.com/planetarium/bencodex.net/pull/98
 
 
 Version 0.13.0


### PR DESCRIPTION
Completely removes "backtracking" the internal `Stream`.

# Benchmark

Yada yada, details as usual. 😗

## 0.13.0

|           Method | SetSize | WordSize |        Mean |     Error |    StdDev |  Allocated |
|----------------- |-------- |--------- |------------:|----------:|----------:|-----------:|
|       DecodeList |      10 |       10 |    11.69 ms |  0.546 ms |  0.607 ms |   21.51 MB |
|       DecodeDict |      10 |       10 |    31.25 ms |  1.672 ms |  1.926 ms |    39.9 MB |
| DecodeNestedList |      10 |       10 |   112.11 ms |  6.247 ms |  7.194 ms |  208.08 MB |
| DecodeNestedDict |      10 |       10 |   340.04 ms | 16.346 ms | 18.825 ms |  410.32 MB |

## Updated

|           Method | SetSize | WordSize |         Mean |      Error |     StdDev |  Allocated |
|----------------- |-------- |--------- |-------------:|-----------:|-----------:|-----------:|
|       DecodeList |      10 |       10 |     9.432 ms |  0.3878 ms |  0.4310 ms |   21.13 MB |
|       DecodeDict |      10 |       10 |    27.225 ms |  2.4504 ms |  2.6219 ms |   39.51 MB |
| DecodeNestedList |      10 |       10 |    90.645 ms |  4.4703 ms |  5.1480 ms |  207.71 MB |
| DecodeNestedDict |      10 |       10 |   295.134 ms | 19.0030 ms | 21.8838 ms |  409.95 MB |