### PR TITLE
Streamline `List` equality

### DIFF
--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -6,8 +6,6 @@ using Bencodex.Types;
 using Xunit;
 using static Bencodex.Misc.ImmutableByteArrayExtensions;
 using static Bencodex.Tests.TestUtils;
-using IEquatableValues =
-    System.IEquatable<System.Collections.Immutable.IImmutableList<Bencodex.Types.IValue>>;
 
 namespace Bencodex.Tests.Types
 {
@@ -204,48 +202,22 @@ namespace Bencodex.Tests.Types
         public void Equality()
         {
             Assert.True(_zero.Equals(new List()));
-            Assert.True(((IEquatableValues)_zero).Equals(ImmutableArray<IValue>.Empty));
             Assert.True(_one.Equals(new List(Null.Value)));
-            Assert.True(
-                ((IEquatableValues)_one).Equals(ImmutableArray<IValue>.Empty.Add(Null.Value))
-            );
             Assert.True(_two.Equals(new List((Text)"hello", (Text)"world")));
-            Assert.True(
-                ((IEquatableValues)_two).Equals(
-                    ImmutableArray.Create<IValue>((Text)"hello", (Text)"world")
-                )
-            );
             Assert.True(_nest.Equals(new List(Null.Value, _zero, _one, _two)));
-            Assert.True(
-                ((IEquatableValues)_nest).Equals(
-                    ImmutableArray.Create<IValue>(Null.Value, _zero, _one, _two)
-                )
-            );
 
             Assert.False(_zero.Equals(_one));
-            Assert.False(((IEquatableValues)_zero).Equals(_one));
             Assert.False(_zero.Equals(_two));
-            Assert.False(((IEquatableValues)_zero).Equals(_two));
             Assert.False(_zero.Equals(_nest));
-            Assert.False(((IEquatableValues)_zero).Equals(_nest));
             Assert.False(_one.Equals(_zero));
-            Assert.False(((IEquatableValues)_one).Equals(_zero));
             Assert.False(_one.Equals(_two));
-            Assert.False(((IEquatableValues)_one).Equals(_two));
             Assert.False(_one.Equals(_nest));
-            Assert.False(((IEquatableValues)_one).Equals(_nest));
             Assert.False(_two.Equals(_zero));
-            Assert.False(((IEquatableValues)_two).Equals(_zero));
             Assert.False(_two.Equals(_one));
-            Assert.False(((IEquatableValues)_two).Equals(_one));
             Assert.False(_two.Equals(_nest));
-            Assert.False(((IEquatableValues)_two).Equals(_nest));
             Assert.False(_nest.Equals(_one));
-            Assert.False(((IEquatableValues)_nest).Equals(_one));
             Assert.False(_nest.Equals(_two));
-            Assert.False(((IEquatableValues)_nest).Equals(_two));
             Assert.False(_nest.Equals(_two));
-            Assert.False(((IEquatableValues)_nest).Equals(_two));
         }
 
         [Fact]

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -16,7 +16,6 @@ namespace Bencodex.Types
     public sealed class List :
         IValue,
         IImmutableList<IValue>,
-        IEquatable<IImmutableList<IValue>>,
         IEquatable<List>
     {
         /// <summary>
@@ -259,35 +258,29 @@ namespace Bencodex.Types
         /// <inheritdoc cref="IReadOnlyList{T}.this[int]"/>
         public IValue this[int index] => _values[index];
 
-        bool IEquatable<IImmutableList<IValue>>.Equals(IImmutableList<IValue> other)
+        public override bool Equals(object obj) => obj is List l && Equals(l);
+
+        public bool Equals(IValue other) => other is List l && Equals(l);
+
+        public bool Equals(List other)
         {
-            if (Count != other.Count)
+            if (Count == other.Count)
+            {
+                for (int i = 0; i < Count; i++)
+                {
+                    if (!_values[i].Equals(other[i]))
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
+            }
+            else
             {
                 return false;
             }
-            else if (other is List otherList)
-            {
-                return Fingerprint.Equals(otherList.Fingerprint);
-            }
-
-            for (int i = 0; i < _values.Length; i++)
-            {
-                IValue v = _values[i];
-                IValue ov = other[i];
-                if (!ov.Equals(v))
-                {
-                    return false;
-                }
-            }
-
-            return true;
         }
-
-        /// <inheritdoc cref="IEquatable{T}.Equals(T)"/>
-        public bool Equals(List other) => Fingerprint.Equals(other.Fingerprint);
-
-        bool IEquatable<IValue>.Equals(IValue other) =>
-            other is List o && Equals(o);
 
         IEnumerator<IValue> IEnumerable<IValue>.GetEnumerator()
         {
@@ -296,10 +289,6 @@ namespace Bencodex.Types
                 yield return element;
             }
         }
-
-        /// <inheritdoc cref="object.Equals(object?)"/>
-        public override bool Equals(object? obj) => obj is List other &&
-            ((IEquatable<IImmutableList<IValue>>)this).Equals(other);
 
         /// <inheritdoc cref="object.GetHashCode()"/>
         public override int GetHashCode()

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ To be released.
  -  Changed the behaviors of `Binary.Equals()` and `Binary.CompareTo()`
     to be more consistent.  [[#106], [#110]]
  -  Removed `ByteArrayComparer` and `FingerprintComparer`.  [[#111]]
+ -  Removed `IEquatable<IImmutableList<IValue>>` from `List`.  [[#104], [#112]]
 
 [#104]: https://github.com/planetarium/bencodex.net/issues/104
 [#106]: https://github.com/planetarium/bencodex.net/issues/106
@@ -29,6 +30,7 @@ To be released.
 [#109]: https://github.com/planetarium/bencodex.net/pull/109
 [#110]: https://github.com/planetarium/bencodex.net/pull/110
 [#111]: https://github.com/planetarium/bencodex.net/pull/111
+[#112]: https://github.com/planetarium/bencodex.net/pull/112
 
 
 Version 0.14.0


### PR DESCRIPTION
This fixes similar problems present in #110 for `Binary`.