### PR TITLE
🧹 Removed unused parameter from Inspect()

### DIFF
--- a/Bencodex.Tests/CodecTest.cs
+++ b/Bencodex.Tests/CodecTest.cs
@@ -29,7 +29,7 @@ namespace Bencodex.Tests
             _output.WriteLine("Data: {0}", spec.EncodingPath);
             Codec codec = new Codec();
             IValue decoded = codec.Decode(spec.Encoding);
-            _output.WriteLine("Value: {0}", decoded.Inspect(false));
+            _output.WriteLine("Value: {0}", decoded.Inspect());
             Assert.Equal(spec.Semantics, decoded);
             Assert.Equal(spec.Encoding.LongLength, decoded.EncodingLength);
             Assert.Equal(spec.Semantics.EncodingLength, decoded.EncodingLength);

--- a/Bencodex.Tests/Types/BinaryTest.cs
+++ b/Bencodex.Tests/Types/BinaryTest.cs
@@ -178,13 +178,11 @@ namespace Bencodex.Tests.Types
             Assert.Equal(13L, new Binary(new byte[10]).EncodingLength);
         }
 
-        [Theory]
-        [InlineData(new object[] { false })]
-        [InlineData(new object[] { true })]
-        public void Inspect(bool loadAll)
+        [Fact]
+        public void Inspect()
         {
-            Assert.Equal("b\"\"", _empty.Inspect(loadAll));
-            Assert.Equal(@"b""\x68\x65\x6c\x6c\x6f""", _hello.Inspect(loadAll));
+            Assert.Equal("b\"\"", _empty.Inspect());
+            Assert.Equal(@"b""\x68\x65\x6c\x6c\x6f""", _hello.Inspect());
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/BooleanTest.cs
+++ b/Bencodex.Tests/Types/BooleanTest.cs
@@ -37,13 +37,11 @@ namespace Bencodex.Tests.Types
             );
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Inspect(bool loadAll)
+        [Fact]
+        public void Inspect()
         {
-            Assert.Equal("true", _t.Inspect(loadAll));
-            Assert.Equal("false", _f.Inspect(loadAll));
+            Assert.Equal("true", _t.Inspect());
+            Assert.Equal("false", _f.Inspect());
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/DictionaryTest.cs
+++ b/Bencodex.Tests/Types/DictionaryTest.cs
@@ -558,20 +558,18 @@ namespace Bencodex.Tests.Types
             Assert.Equal(33L, _mixedKeys.EncodingLength);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Inspect(bool loadAll)
+        [Fact]
+        public void Inspect()
         {
-            Assert.Equal("{}", Dictionary.Empty.Inspect(loadAll));
+            Assert.Equal("{}", Dictionary.Empty.Inspect());
 
             Assert.Equal(
                 "{\n  \"foo\": \"bar\",\n}",
-                _textKey.Inspect(loadAll)
+                _textKey.Inspect()
             );
             Assert.Equal(
                 "{\n  b\"\\x66\\x6f\\x6f\": \"bar\",\n}",
-                _binaryKey.Inspect(loadAll)
+                _binaryKey.Inspect()
             );
             Assert.Equal(
                 @"{
@@ -580,7 +578,7 @@ namespace Bencodex.Tests.Types
   },
   ""foo"": ""bar"",
 }".NoCr(),
-                _textKey.SetItem("baz", _textKey).Inspect(loadAll)
+                _textKey.SetItem("baz", _textKey).Inspect()
             );
         }
 

--- a/Bencodex.Tests/Types/IntegerTest.cs
+++ b/Bencodex.Tests/Types/IntegerTest.cs
@@ -160,13 +160,11 @@ namespace Bencodex.Tests.Types
             Assert.Equal(6L, new Integer(-456).EncodingLength);
         }
 
-        [Theory]
-        [InlineData(new object[] { false })]
-        [InlineData(new object[] { true })]
-        public void Inspect(bool loadAll)
+        [Fact]
+        public void Inspect()
         {
-            Assert.Equal("123", new Integer(123).Inspect(loadAll));
-            Assert.Equal("-456", new Integer(-456).Inspect(loadAll));
+            Assert.Equal("123", new Integer(123).Inspect());
+            Assert.Equal("-456", new Integer(-456).Inspect());
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/ListTest.cs
+++ b/Bencodex.Tests/Types/ListTest.cs
@@ -98,14 +98,12 @@ namespace Bencodex.Tests.Types
             Assert.Equal(26L, _nest.EncodingLength);
         }
 
-        [Theory]
-        [InlineData(false)]
-        [InlineData(true)]
-        public void Inspect(bool loadAll)
+        [Fact]
+        public void Inspect()
         {
-            Assert.Equal("[]", _zero.Inspect(loadAll));
-            Assert.Equal("[null]", _one.Inspect(loadAll));
-            Assert.Equal("[\n  \"hello\",\n  \"world\",\n]", _two.Inspect(loadAll));
+            Assert.Equal("[]", _zero.Inspect());
+            Assert.Equal("[null]", _one.Inspect());
+            Assert.Equal("[\n  \"hello\",\n  \"world\",\n]", _two.Inspect());
 
             var expected = @"[
   null,
@@ -116,11 +114,11 @@ namespace Bencodex.Tests.Types
     ""world"",
   ],
 ]".NoCr();
-            Assert.Equal(expected, _nest.Inspect(loadAll));
+            Assert.Equal(expected, _nest.Inspect());
 
             // If any element is a list/dict it should be indented
-            Assert.Equal("[\n  [],\n]", new List(new IValue[] { _zero }).Inspect(loadAll));
-            Assert.Equal("[\n  {},\n]", new List(Dictionary.Empty).Inspect(loadAll));
+            Assert.Equal("[\n  [],\n]", new List(new IValue[] { _zero }).Inspect());
+            Assert.Equal("[\n  {},\n]", new List(Dictionary.Empty).Inspect());
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/NullTest.cs
+++ b/Bencodex.Tests/Types/NullTest.cs
@@ -25,12 +25,10 @@ namespace Bencodex.Tests.Types
             Assert.Equal(ValueKind.Null, Null.Value.Kind);
         }
 
-        [Theory]
-        [InlineData(new object[] { false })]
-        [InlineData(new object[] { true })]
-        public void Inspect(bool loadAll)
+        [Fact]
+        public void Inspect()
         {
-            Assert.Equal("null", Null.Value.Inspect(loadAll));
+            Assert.Equal("null", Null.Value.Inspect());
         }
 
         [Fact]

--- a/Bencodex.Tests/Types/TextTest.cs
+++ b/Bencodex.Tests/Types/TextTest.cs
@@ -111,16 +111,14 @@ namespace Bencodex.Tests.Types
             );
         }
 
-        [Theory]
-        [InlineData(new object[] { false })]
-        [InlineData(new object[] { true })]
-        public void Inspect(bool loadAll)
+        [Fact]
+        public void Inspect()
         {
-            Assert.Equal("\"\"", _empty.Inspect(loadAll));
-            Assert.Equal("\"\u4f60\u597d\"", _nihao.Inspect(loadAll));
+            Assert.Equal("\"\"", _empty.Inspect());
+            Assert.Equal("\"\u4f60\u597d\"", _nihao.Inspect());
             Assert.Equal(
                 "\"new lines and\\n\\\"quotes\\\" become escaped to \\\\\"",
-                _complex.Inspect(loadAll)
+                _complex.Inspect()
             );
         }
 

--- a/Bencodex/Types/Binary.cs
+++ b/Bencodex/Types/Binary.cs
@@ -317,8 +317,8 @@ namespace Bencodex.Types
             return Convert.ToBase64String(Unsafe.As<ImmutableArray<byte>, byte[]>(ref bytes));
         }
 
-        /// <inheritdoc cref="IValue.Inspect(bool)"/>
-        public string Inspect(bool loadAll)
+        /// <inheritdoc cref="IValue.Inspect()"/>
+        public string Inspect()
         {
             IEnumerable<string> contents = this.Select(b => $"\\x{b:x2}");
             return $"b\"{string.Join(string.Empty, contents)}\"";
@@ -326,6 +326,6 @@ namespace Bencodex.Types
 
         /// <inheritdoc cref="object.ToString()"/>
         public override string ToString() =>
-            $"{nameof(Bencodex)}.{nameof(Bencodex.Types)}.{nameof(Binary)} {Inspect(false)}";
+            $"{nameof(Bencodex)}.{nameof(Bencodex.Types)}.{nameof(Binary)} {Inspect()}";
     }
 }

--- a/Bencodex/Types/Boolean.cs
+++ b/Bencodex/Types/Boolean.cs
@@ -88,13 +88,12 @@ namespace Bencodex.Types
             return Value.GetHashCode();
         }
 
-        /// <inheritdoc cref="IValue.Inspect(bool)"/>
-        public string Inspect(bool loadAll) =>
-            Value ? "true" : "false";
+        /// <inheritdoc cref="IValue.Inspect()"/>
+        public string Inspect() => Value ? "true" : "false";
 
         /// <inheritdoc cref="object.ToString()"/>
         [Pure]
         public override string ToString() =>
-            $"{nameof(Bencodex)}.{nameof(Types)}.{nameof(Boolean)} {Inspect(false)}";
+            $"{nameof(Bencodex)}.{nameof(Types)}.{nameof(Boolean)} {Inspect()}";
     }
 }

--- a/Bencodex/Types/Dictionary.cs
+++ b/Bencodex/Types/Dictionary.cs
@@ -1676,8 +1676,8 @@ namespace Bencodex.Types
             => unchecked(_dict.Aggregate(GetType().GetHashCode(), (accum, next)
                 => (accum * 397) ^ ((next.Key.GetHashCode() * 397) ^ next.Value.GetHashCode())));
 
-        /// <inheritdoc cref="IValue.Inspect(bool)"/>
-        public string Inspect(bool loadAll)
+        /// <inheritdoc cref="IValue.Inspect()"/>
+        public string Inspect()
         {
             if (_dict.Count < 1)
             {
@@ -1685,7 +1685,7 @@ namespace Bencodex.Types
             }
 
             IEnumerable<string> pairs = this.Select(kv =>
-                $"  {kv.Key.Inspect(loadAll)}: {kv.Value.Inspect(loadAll).Replace("\n", "\n  ")},\n"
+                $"  {kv.Key.Inspect()}: {kv.Value.Inspect().Replace("\n", "\n  ")},\n"
             ).OrderBy(s => s);
             string pairsString = string.Join(string.Empty, pairs);
             return $"{{\n{pairsString}}}";
@@ -1693,6 +1693,6 @@ namespace Bencodex.Types
 
         /// <inheritdoc cref="object.ToString()"/>
         public override string ToString() =>
-            $"{nameof(Bencodex)}.{nameof(Types)}.{nameof(Dictionary)} {Inspect(false)}";
+            $"{nameof(Bencodex)}.{nameof(Types)}.{nameof(Dictionary)} {Inspect()}";
     }
 }

--- a/Bencodex/Types/IValue.cs
+++ b/Bencodex/Types/IValue.cs
@@ -26,13 +26,9 @@ namespace Bencodex.Types
 
         /// <summary>
         /// Gets a human-readable representation for debugging.
-        /// <para>Unloaded values may be omitted.</para>
         /// </summary>
-        /// <param name="loadAll">Load all unloaded values before showing them.  This option
-        /// is applied to subtrees recursively.</param>
         /// <returns>A human-readable representation for debugging, which looks similar to Python's
-        /// literal syntax.  However, if a value is a complex tree and contains any unloaded
-        /// subvalues, these are omitted and their fingerprints are shown instead.</returns>
-        string Inspect(bool loadAll);
+        /// literal syntax.</returns>
+        string Inspect();
     }
 }

--- a/Bencodex/Types/Integer.cs
+++ b/Bencodex/Types/Integer.cs
@@ -223,13 +223,13 @@ namespace Bencodex.Types
             return Value.GetHashCode();
         }
 
-        /// <inheritdoc cref="IValue.Inspect(bool)"/>
-        public string Inspect(bool loadAll) =>
+        /// <inheritdoc cref="IValue.Inspect()"/>
+        public string Inspect() =>
             Value.ToString(CultureInfo.InvariantCulture);
 
         /// <inheritdoc cref="object.ToString()"/>
         public override string ToString() =>
-            $"{nameof(Bencodex)}.{nameof(Types)}.{nameof(Integer)} {Inspect(false)}";
+            $"{nameof(Bencodex)}.{nameof(Types)}.{nameof(Integer)} {Inspect()}";
 
         internal long CountDecimalDigits() =>
             Value.Sign switch

--- a/Bencodex/Types/List.cs
+++ b/Bencodex/Types/List.cs
@@ -464,10 +464,10 @@ namespace Bencodex.Types
         IImmutableList<IValue> IImmutableList<IValue>.SetItem(int index, IValue value) =>
             new List(_values.SetItem(index, value));
 
-        /// <inheritdoc cref="IValue.Inspect(bool)"/>
-        public string Inspect(bool loadAll)
+        /// <inheritdoc cref="IValue.Inspect()"/>
+        public string Inspect()
         {
-            string InspectItem(IValue value, bool load) => value.Inspect(load);
+            string InspectItem(IValue value) => value.Inspect();
 
             string inspection;
             switch (_values.Length)
@@ -483,12 +483,12 @@ namespace Bencodex.Types
                         goto default;
                     }
 
-                    inspection = $"[{InspectItem(first, loadAll)}]";
+                    inspection = $"[{InspectItem(first)}]";
                     break;
 
                 default:
                     IEnumerable<string> elements = _values.Select(v =>
-                        $"  {InspectItem(v, loadAll).Replace("\n", "\n  ")},\n"
+                        $"  {InspectItem(v).Replace("\n", "\n  ")},\n"
                     );
                     inspection = $"[\n{string.Join(string.Empty, elements)}]";
                     break;
@@ -499,6 +499,6 @@ namespace Bencodex.Types
 
         /// <inheritdoc cref="object.ToString()"/>
         public override string ToString() =>
-            $"{nameof(Bencodex)}.{nameof(Types)}.{nameof(List)} {Inspect(false)}";
+            $"{nameof(Bencodex)}.{nameof(Types)}.{nameof(List)} {Inspect()}";
     }
 }

--- a/Bencodex/Types/Null.cs
+++ b/Bencodex/Types/Null.cs
@@ -43,8 +43,8 @@ namespace Bencodex.Types
 
         bool IEquatable<Null>.Equals(Null other) => true;
 
-        /// <inheritdoc cref="IValue.Inspect(bool)"/>
-        public string Inspect(bool loadAll) => "null";
+        /// <inheritdoc cref="IValue.Inspect()"/>
+        public string Inspect() => "null";
 
         /// <inheritdoc cref="object.ToString()"/>
         public override string ToString() =>

--- a/Bencodex/Types/Text.cs
+++ b/Bencodex/Types/Text.cs
@@ -95,8 +95,8 @@ namespace Bencodex.Types
             throw new ArgumentException($"Object must be of type {nameof(Text)}");
         }
 
-        /// <inheritdoc cref="IValue.Inspect(bool)"/>
-        public string Inspect(bool loadAll)
+        /// <inheritdoc cref="IValue.Inspect()"/>
+        public string Inspect()
         {
             string contents = Value
                 .Replace("\\", "\\\\")
@@ -107,6 +107,6 @@ namespace Bencodex.Types
 
         /// <inheritdoc cref="object.ToString()"/>
         public override string ToString() =>
-            $"{nameof(Bencodex)}.{nameof(Types)}.{nameof(Text)} {Inspect(false)}";
+            $"{nameof(Bencodex)}.{nameof(Types)}.{nameof(Text)} {Inspect()}";
     }
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,10 @@ Version 0.16.0
 To be released.
 
  -  Removed `IValue.Inspection` property.  [[#117]]
+ -  Changed `IValue.Inspect(bool)` to `IValue.Inspect()`.  [[#118]]
 
 [#117]: https://github.com/planetarium/bencodex.net/pull/117
+[#118]: https://github.com/planetarium/bencodex.net/pull/118
 
 
 Version 0.15.0


### PR DESCRIPTION
🧹 Since `Fingerprint` was removed in 0.15.0, there is no difference between `Inspect(true)` and `Inspect(false)` (which has always been the case as offloading was never used). 🙄