### PR TITLE
Optimized `Encoder.Encode()`

### DIFF
--- a/Bencodex.Tests/EncoderTest.cs
+++ b/Bencodex.Tests/EncoderTest.cs
@@ -30,8 +30,9 @@ namespace Bencodex.Tests
         public void EncodeNull()
         {
             var buffer = new byte[10];
-            long size = Encoder.EncodeNull(buffer, 3L);
-            Assert.Equal(1L, size);
+            long offset = 3L;
+            Encoder.EncodeNull(buffer, ref offset);
+            Assert.Equal(3L + 1L, offset);
             AssertEqual(new byte[] { 0, 0, 0, 0x6e, 0, 0, 0, 0, 0, 0 }, buffer);
         }
 
@@ -39,12 +40,14 @@ namespace Bencodex.Tests
         public void EncodeBoolean()
         {
             var buffer = new byte[10];
-            long size = Encoder.EncodeBoolean(new Boolean(true), buffer, 2L);
-            Assert.Equal(1L, size);
+            long offset = 2L;
+            Encoder.EncodeBoolean(new Boolean(true), buffer, ref offset);
+            Assert.Equal(2L + 1L, offset);
             AssertEqual(new byte[] { 0, 0, 0x74, 0, 0, 0, 0, 0, 0, 0 }, buffer);
 
-            size = Encoder.EncodeBoolean(new Boolean(false), buffer, 5L);
-            Assert.Equal(1L, size);
+            offset = 5L;
+            Encoder.EncodeBoolean(new Boolean(false), buffer, ref offset);
+            Assert.Equal(5L + 1L, offset);
             AssertEqual(new byte[] { 0, 0, 0x74, 0, 0, 0x66, 0, 0, 0, 0 }, buffer);
         }
 
@@ -52,18 +55,21 @@ namespace Bencodex.Tests
         public void EncodeInteger()
         {
             var buffer = new byte[10];
-            long size = Encoder.EncodeInteger(0, buffer, 2L);
-            Assert.Equal(3L, size);
+            long offset = 2L;
+            Encoder.EncodeInteger(0, buffer, ref offset);
+            Assert.Equal(2L + 3L, offset);
             AssertEqual(new byte[] { 0, 0, 0x69, 0x30, 0x65, 0, 0, 0, 0, 0 }, buffer);
 
             Clear(buffer, 0, buffer.Length);
-            size = Encoder.EncodeInteger(-123, buffer, 1L);
-            Assert.Equal(6L, size);
+            offset = 1L;
+            Encoder.EncodeInteger(-123, buffer, ref offset);
+            Assert.Equal(1L + 6L, offset);
             AssertEqual(new byte[] { 0, 0x69, 0x2d, 0x31, 0x32, 0x33, 0x65, 0, 0, 0 }, buffer);
 
             Clear(buffer, 0, buffer.Length);
-            size = Encoder.EncodeInteger(456, buffer, 4L);
-            Assert.Equal(5L, size);
+            offset = 4L;
+            Encoder.EncodeInteger(456, buffer, ref offset);
+            Assert.Equal(4L + 5L, offset);
             AssertEqual(new byte[] { 0, 0, 0, 0, 0x69, 0x34, 0x35, 0x36, 0x65, 0 }, buffer);
         }
 
@@ -71,8 +77,9 @@ namespace Bencodex.Tests
         public void EncodeBinary()
         {
             var buffer = new byte[20];
-            long size = Encoder.EncodeBinary(new Binary("hello world", Encoding.ASCII), buffer, 2L);
-            Assert.Equal(14L, size);
+            long offset = 2L;
+            Encoder.EncodeBinary(new Binary("hello world", Encoding.ASCII), buffer, ref offset);
+            Assert.Equal(2L + 14L, offset);
             AssertEqual(
                 new byte[20]
                 {
@@ -90,8 +97,9 @@ namespace Bencodex.Tests
         public void EncodeText()
         {
             var buffer = new byte[20];
-            long size = Encoder.EncodeText("한글", buffer, 5L);
-            Assert.Equal(9L, size);
+            long offset = 5L;
+            Encoder.EncodeText("한글", buffer, ref offset);
+            Assert.Equal(5L + 9L, offset);
             AssertEqual(
                 new byte[20]
                 {
@@ -130,28 +138,33 @@ namespace Bencodex.Tests
         public void EncodeDigits()
         {
             var buffer = new byte[10];
-            long size = Encoder.EncodeDigits(0L, buffer, 2L);
-            Assert.Equal(1L, size);
+            long offset = 2L;
+            Encoder.EncodeDigits(0L, buffer, ref offset);
+            Assert.Equal(2L + 1L, offset);
             AssertEqual(new byte[] { 0, 0, 0x30, 0, 0, 0, 0, 0, 0, 0 }, buffer);
 
             Clear(buffer, 0, buffer.Length);
-            size = Encoder.EncodeDigits(5L, buffer, 0L);
-            Assert.Equal(1L, size);
+            offset = 0L;
+            Encoder.EncodeDigits(5L, buffer, ref offset);
+            Assert.Equal(0L + 1L, offset);
             AssertEqual(new byte[] { 0x35, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, buffer);
 
             Clear(buffer, 0, buffer.Length);
-            size = Encoder.EncodeDigits(10L, buffer, 5L);
-            Assert.Equal(2L, size);
+            offset = 5L;
+            Encoder.EncodeDigits(10L, buffer, ref offset);
+            Assert.Equal(5L + 2L, offset);
             AssertEqual(new byte[] { 0, 0, 0, 0, 0, 0x31, 0x30, 0, 0, 0 }, buffer);
 
             Clear(buffer, 0, buffer.Length);
-            size = Encoder.EncodeDigits(123L, buffer, 6L);
-            Assert.Equal(3L, size);
+            offset = 6L;
+            Encoder.EncodeDigits(123L, buffer, ref offset);
+            Assert.Equal(6L + 3L, offset);
             AssertEqual(new byte[] { 0, 0, 0, 0, 0, 0, 0x31, 0x32, 0x33, 0 }, buffer);
 
             Clear(buffer, 0, buffer.Length);
-            size = Encoder.EncodeDigits(9876543210L, buffer, 0L);
-            Assert.Equal(10L, size);
+            offset = 0L;
+            Encoder.EncodeDigits(9876543210L, buffer, ref offset);
+            Assert.Equal(0L + 10L, offset);
             AssertEqual(
                 new byte[] { 0x39, 0x38, 0x37, 0x36, 0x35, 0x34, 0x33, 0x32, 0x31, 0x30 },
                 buffer

--- a/Bencodex/Encoder.cs
+++ b/Bencodex/Encoder.cs
@@ -14,7 +14,8 @@ namespace Bencodex
         {
             long estimatedLength = EstimateLength(value);
             var buffer = new byte[estimatedLength];
-            Encode(value, buffer, 0L);
+            long offset = 0;
+            Encode(value, buffer, ref offset);
             return buffer;
         }
 
@@ -68,24 +69,21 @@ namespace Bencodex
             return value.EncodingLength;
         }
 
-        internal static long EncodeNull(byte[] buffer, long offset)
+        internal static void EncodeNull(byte[] buffer, ref long offset)
         {
-            buffer[offset] = 0x6e;  // 'n'
-            return 1L;
+            buffer[offset++] = 0x6e;  // 'n'
         }
 
-        internal static long EncodeBoolean(in Types.Boolean value, byte[] buffer, long offset)
+        internal static void EncodeBoolean(in Types.Boolean value, byte[] buffer, ref long offset)
         {
-            buffer[offset] = value.Value
+            buffer[offset++] = value.Value
                 ? (byte)0x74 // 't'
                 : (byte)0x66; // 'f'
-            return 1L;
         }
 
-        internal static long EncodeInteger(in Integer value, byte[] buffer, long offset)
+        internal static void EncodeInteger(in Integer value, byte[] buffer, ref long offset)
         {
-            buffer[offset] = 0x69;  // 'i'
-            offset++;
+            buffer[offset++] = 0x69;  // 'i'
             string digits = value.Value.ToString(CultureInfo.InvariantCulture);
             if (offset + digits.Length <= int.MaxValue)
             {
@@ -98,104 +96,89 @@ namespace Bencodex
             }
 
             offset += digits.Length;
-            buffer[offset] = 0x65;  // 'e'
-            return 1L + digits.Length + 1L;
+            buffer[offset++] = 0x65;  // 'e'
         }
 
-        internal static long EncodeBinary(in Binary value, byte[] buffer, long offset)
+        internal static void EncodeBinary(in Binary value, byte[] buffer, ref long offset)
         {
             long len = value.ByteArray.Length;
-            long lenStrLength = EncodeDigits(len, buffer, offset);
-            offset += lenStrLength;
-            buffer[offset] = 0x3a;  // ':'
-            offset++;
+            EncodeDigits(len, buffer, ref offset);
+            buffer[offset++] = 0x3a;  // ':'
 
             if (offset + len <= int.MaxValue)
             {
                 value.ByteArray.CopyTo(buffer, (int)offset);
-                return lenStrLength + 1L + len;
+                offset += len;
+                return;
             }
 
             byte[] b = value.ToByteArray();
             Array.Copy(b, 0L, buffer, offset, b.LongLength);
-            return lenStrLength + 1L + b.LongLength;
+            offset += len;
+            return;
         }
 
-        internal static long EncodeText(in Text value, byte[] buffer, long offset)
+        internal static void EncodeText(in Text value, byte[] buffer, ref long offset)
         {
             buffer[offset++] = 0x75;  // 'u'
             int utf8Length = value.Utf8Length;
-            long lenStrLength = EncodeDigits(utf8Length, buffer, offset);
-            offset += lenStrLength;
-            buffer[offset] = 0x3a;  // ':'
-            offset++;
+
+            EncodeDigits(utf8Length, buffer, ref offset);
+            buffer[offset++] = 0x3a;  // ':'
+
             string str = value.Value;
 
             if (offset + str.Length <= int.MaxValue)
             {
                 Encoding.UTF8.GetBytes(str, 0, str.Length, buffer, (int)offset);
-                return 1L + lenStrLength + 1L + utf8Length;
+                offset += utf8Length;
+                return;
             }
 
             byte[] utf8 = Encoding.UTF8.GetBytes(value.Value);
             Array.Copy(utf8, 0L, buffer, offset, utf8.LongLength);
-            return 1L + lenStrLength + 1L + utf8.LongLength;
+            offset += utf8.LongLength;
+            return;
         }
 
         // TODO: Needs a unit test.
-        internal static long EncodeList(
-            in List value,
-            byte[] buffer,
-            long offset
-        )
+        internal static void EncodeList(in List value, byte[] buffer, ref long offset)
         {
-            buffer[offset] = 0x6c;  // 'l'
-            long encLen = 1L;  // This means the logical "expanded" encoding length.
-            long actualBytes = 1L;  // This means the actual "collapsed" encoding length.
+            buffer[offset++] = 0x6c;  // 'l'
             foreach (IValue v in value)
             {
-                actualBytes += Encode(v, buffer, offset + actualBytes);
-                encLen += v.EncodingLength;
+                Encode(v, buffer, ref offset);
             }
 
-            offset += actualBytes;
-            buffer[offset] = 0x65;  // 'e'
-            actualBytes++;
-            encLen++;
-            return actualBytes;
+            buffer[offset++] = 0x65;  // 'e'
+            return;
         }
 
         // TODO: Needs a unit test.
-        internal static long EncodeDictionary(
-            in Dictionary value,
-            byte[] buffer,
-            long offset
-        )
+        internal static void EncodeDictionary(in Dictionary value, byte[] buffer, ref long offset)
         {
-            buffer[offset] = 0x64;  // 'd'
-            long encLen = 1L;  // This means the logical "expanded" encoding length.
-            long actualBytes = 1L;  // This means the actual "collapsed" encoding length.
+            buffer[offset++] = 0x64;  // 'd'
+
             foreach (KeyValuePair<IKey, IValue> pair in value)
             {
-                actualBytes += pair.Key switch
+                switch (pair.Key)
                 {
-                    Text tk => EncodeText(tk, buffer, offset + actualBytes),
-                    Binary bk => EncodeBinary(bk, buffer, offset + actualBytes),
-                    { } k => throw new ArgumentException(
-                        $"Unsupported type: {k.GetType()}", nameof(k)),
-                };
+                    case Binary binary:
+                        EncodeBinary(binary, buffer, ref offset);
+                        break;
+                    case Text text:
+                        EncodeText(text, buffer, ref offset);
+                        break;
+                    default:
+                        throw new ArgumentException(
+                            $"Unsupported type: {pair.Key.GetType()}", nameof(pair.Key));
+                }
 
-                actualBytes += Encode(pair.Value, buffer, offset + actualBytes);
-
-                encLen += pair.Key.EncodingLength + pair.Value.EncodingLength;
+                Encode(pair.Value, buffer, ref offset);
             }
 
-            offset += actualBytes;
-            buffer[offset] = 0x65;  // 'e'
-            encLen++;
-            actualBytes++;
-            value.EncodingLength = encLen;
-            return actualBytes;
+            buffer[offset++] = 0x65;  // 'e'
+            return;
         }
 
         internal static long CountDecimalDigits(long value)
@@ -223,7 +206,7 @@ namespace Bencodex
 #pragma warning restore SA1503
         }
 
-        internal static long EncodeDigits(long positiveInt, byte[] buffer, long offset)
+        internal static void EncodeDigits(long positiveInt, byte[] buffer, ref long offset)
         {
             const int asciiZero = 0x30; // '0'
             long length = CountDecimalDigits(positiveInt);
@@ -233,26 +216,39 @@ namespace Bencodex
                 positiveInt /= 10;
             }
 
-            return length;
+            offset += length;
         }
 
         // TODO: Needs a unit test.
-        internal static long Encode(in IValue value, byte[] buffer, long offset)
+        internal static void Encode(in IValue value, byte[] buffer, ref long offset)
         {
-            return value switch
+            switch (value)
             {
-                Null _ => EncodeNull(buffer, offset),
-                Types.Boolean b => EncodeBoolean(b, buffer, offset),
-                Integer i => EncodeInteger(i, buffer, offset),
-                Binary bin => EncodeBinary(bin, buffer, offset),
-                Text t => EncodeText(t, buffer, offset),
-                List l => EncodeList(l, buffer, offset),
-                Dictionary d => EncodeDictionary(d, buffer, offset),
-                _ =>
+                case Null _:
+                    EncodeNull(buffer, ref offset);
+                    break;
+                case Types.Boolean boolean:
+                    EncodeBoolean(boolean, buffer, ref offset);
+                    break;
+                case Integer integer:
+                    EncodeInteger(integer, buffer, ref offset);
+                    break;
+                case Binary binary:
+                    EncodeBinary(binary, buffer, ref offset);
+                    break;
+                case Text text:
+                    EncodeText(text, buffer, ref offset);
+                    break;
+                case List list:
+                    EncodeList(list, buffer, ref offset);
+                    break;
+                case Dictionary dictionary:
+                    EncodeDictionary(dictionary, buffer, ref offset);
+                    break;
+                default:
                     throw new ArgumentException(
-                        "Unsupported type: " + value.GetType().FullName, nameof(value)
-                    ),
-            };
+                        $"Unsupported type: {value.GetType()}", nameof(value));
+            }
         }
     }
 }

--- a/Bencodex/Encoder.cs
+++ b/Bencodex/Encoder.cs
@@ -9,6 +9,16 @@ namespace Bencodex
 {
     internal static class Encoder
     {
+        private const byte _n = 0x6e;
+        private const byte _t = 0x74;
+        private const byte _f = 0x66;
+        private const byte _i = 0x69;
+        private const byte _c = 0x3a;   // `:`
+        private const byte _e = 0x65;
+        private const byte _u = 0x75;
+        private const byte _l = 0x6c;
+        private const byte _d = 0x64;
+
         // TODO: Needs a unit test.
         public static byte[] Encode(IValue value)
         {
@@ -36,24 +46,24 @@ namespace Bencodex
                 switch (value)
                 {
                     case List l:
-                        output.WriteByte(0x6c);  // 'l'
+                        output.WriteByte(_l);
                         foreach (IValue el in l)
                         {
                             Encode(el, output);
                         }
 
-                        output.WriteByte(0x65);  // 'e'
+                        output.WriteByte(_e);
                         break;
 
                     case Dictionary d:
-                        output.WriteByte(0x6c);  // 'l'
+                        output.WriteByte(_d);
                         foreach (KeyValuePair<IKey, IValue> pair in d)
                         {
                             Encode(pair.Key, output);
                             Encode(pair.Value, output);
                         }
 
-                        output.WriteByte(0x65);  // 'e'
+                        output.WriteByte(_e);
                         break;
                 }
 
@@ -71,19 +81,17 @@ namespace Bencodex
 
         internal static void EncodeNull(byte[] buffer, ref long offset)
         {
-            buffer[offset++] = 0x6e;  // 'n'
+            buffer[offset++] = _n;
         }
 
         internal static void EncodeBoolean(in Types.Boolean value, byte[] buffer, ref long offset)
         {
-            buffer[offset++] = value.Value
-                ? (byte)0x74 // 't'
-                : (byte)0x66; // 'f'
+            buffer[offset++] = value.Value ? _t : _f;
         }
 
         internal static void EncodeInteger(in Integer value, byte[] buffer, ref long offset)
         {
-            buffer[offset++] = 0x69;  // 'i'
+            buffer[offset++] = _i;
             string digits = value.Value.ToString(CultureInfo.InvariantCulture);
             if (offset + digits.Length <= int.MaxValue)
             {
@@ -96,14 +104,14 @@ namespace Bencodex
             }
 
             offset += digits.Length;
-            buffer[offset++] = 0x65;  // 'e'
+            buffer[offset++] = _e;
         }
 
         internal static void EncodeBinary(in Binary value, byte[] buffer, ref long offset)
         {
             long len = value.ByteArray.Length;
             EncodeDigits(len, buffer, ref offset);
-            buffer[offset++] = 0x3a;  // ':'
+            buffer[offset++] = _c;
 
             if (offset + len <= int.MaxValue)
             {
@@ -120,14 +128,12 @@ namespace Bencodex
 
         internal static void EncodeText(in Text value, byte[] buffer, ref long offset)
         {
-            buffer[offset++] = 0x75;  // 'u'
+            buffer[offset++] = _u;
             int utf8Length = value.Utf8Length;
-
             EncodeDigits(utf8Length, buffer, ref offset);
-            buffer[offset++] = 0x3a;  // ':'
+            buffer[offset++] = _c;
 
             string str = value.Value;
-
             if (offset + str.Length <= int.MaxValue)
             {
                 Encoding.UTF8.GetBytes(str, 0, str.Length, buffer, (int)offset);
@@ -144,20 +150,20 @@ namespace Bencodex
         // TODO: Needs a unit test.
         internal static void EncodeList(in List value, byte[] buffer, ref long offset)
         {
-            buffer[offset++] = 0x6c;  // 'l'
+            buffer[offset++] = _l;
             foreach (IValue v in value)
             {
                 Encode(v, buffer, ref offset);
             }
 
-            buffer[offset++] = 0x65;  // 'e'
+            buffer[offset++] = _e;
             return;
         }
 
         // TODO: Needs a unit test.
         internal static void EncodeDictionary(in Dictionary value, byte[] buffer, ref long offset)
         {
-            buffer[offset++] = 0x64;  // 'd'
+            buffer[offset++] = _d;
 
             foreach (KeyValuePair<IKey, IValue> pair in value)
             {
@@ -177,7 +183,7 @@ namespace Bencodex
                 Encode(pair.Value, buffer, ref offset);
             }
 
-            buffer[offset++] = 0x65;  // 'e'
+            buffer[offset++] = _e;
             return;
         }
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,8 +7,11 @@ Version 0.17.0
 To be released.
 
  -  Removed `Dictionary.GetValue<T>()` methods.  [[#122]]
+ -  Optimized `Encoder.Encode()` method.  [[#124]]
+ -  Fixed a bug in `Encoder.Encode(IValue, Stream)` method.  [[#124]]
 
 [#122]: https://github.com/planetarium/bencodex.net/pull/122
+[#124]: https://github.com/planetarium/bencodex.net/pull/124
 
 
 Version 0.16.0


### PR DESCRIPTION
Just squeezing out more performance. 🙄
Depending on the case, the speed gain seems to be about 20% ~ 30%.
On the memory side, the memory usage seems go down more drastically as the collection size gets bigger.

This is achieved through the following:
- Removed value argument passing and returning values for tracking the encoder state.
- Other than declaring temporary local variables, the global `offset` is tracked using a single variable using `ref`.

As a bonus, the code became more readable as well. Also a bug was fixed where an unused overloaded `Encode()` method was wrongly implemented (not sure if we still need to keep the method tho). 😗

## `Encode()` original

|           Method | SetSize | WordSize |       Mean |      Error |     StdDev |       Gen0 | Allocated |
|----------------- |-------- |--------- |-----------:|-----------:|-----------:|-----------:|----------:|
|       EncodeList |       8 |        8 |   3.838 ms |  0.6533 ms |  0.3888 ms |   265.6250 |    1.6 MB |
|       EncodeDict |       8 |        8 |  13.948 ms |  1.2701 ms |  0.8401 ms |   453.1250 |   2.73 MB |
| EncodeNestedList |       8 |        8 |  35.165 ms |  6.0021 ms |  3.9700 ms |  1923.0769 |  11.65 MB |
| EncodeNestedDict |       8 |        8 | 160.819 ms | 25.9170 ms | 17.1425 ms |  3500.0000 |   21.6 MB |
|       EncodeList |       8 |       16 |   5.465 ms |  0.1529 ms |  0.1012 ms |   789.0625 |   4.73 MB |
|       EncodeDict |       8 |       16 |  17.626 ms |  0.6054 ms |  0.3603 ms |  1500.0000 |   8.99 MB |
| EncodeNestedList |       8 |       16 |  45.677 ms |  1.5729 ms |  1.0404 ms |  6090.9091 |  36.67 MB |
| EncodeNestedDict |       8 |       16 | 168.689 ms |  2.9600 ms |  1.9579 ms | 12333.3333 |  74.78 MB |
|       EncodeList |      16 |        8 |   7.854 ms |  0.1353 ms |  0.0895 ms |   390.6250 |   2.42 MB |
|       EncodeDict |      16 |        8 |  31.121 ms |  1.2161 ms |  0.8044 ms |   718.7500 |   4.33 MB |
| EncodeNestedList |      16 |        8 | 130.883 ms |  1.7192 ms |  1.0231 ms |  5750.0000 |   35.3 MB |
| EncodeNestedDict |      16 |        8 | 521.700 ms | 10.7511 ms |  7.1112 ms | 11000.0000 |  67.73 MB |
|       EncodeList |      16 |       16 |  10.420 ms |  0.4796 ms |  0.2854 ms |  1437.5000 |   8.68 MB |
|       EncodeDict |      16 |       16 |  33.950 ms |  1.6944 ms |  1.1208 ms |  2785.7143 |  16.84 MB |
| EncodeNestedList |      16 |       16 | 160.629 ms |  3.9966 ms |  2.6435 ms | 22500.0000 |  135.4 MB |
| EncodeNestedDict |      16 |       16 | 581.700 ms |  5.6855 ms |  3.3833 ms | 45000.0000 | 274.18 MB |

## `Encode()` optimized

|           Method | SetSize | WordSize |       Mean |      Error |     StdDev |       Gen0 | Allocated |
|----------------- |-------- |--------- |-----------:|-----------:|-----------:|-----------:|----------:|
|       EncodeList |       8 |        8 |   3.322 ms |  0.5204 ms |  0.3442 ms |   265.6250 |   1.61 MB |
|       EncodeDict |       8 |        8 |  13.067 ms |  1.4576 ms |  0.9641 ms |   453.1250 |   2.73 MB |
| EncodeNestedList |       8 |        8 |  30.082 ms |  2.4822 ms |  1.4771 ms |  1937.5000 |  11.65 MB |
| EncodeNestedDict |       8 |        8 | 124.848 ms | 11.0279 ms |  7.2943 ms |  3500.0000 |  21.61 MB |
|       EncodeList |       8 |       16 |   3.674 ms |  0.4520 ms |  0.2989 ms |   382.8125 |   2.29 MB |
|       EncodeDict |       8 |       16 |  13.914 ms |  1.5466 ms |  1.0230 ms |   671.8750 |    4.1 MB |
| EncodeNestedList |       8 |       16 |  34.074 ms |  4.8878 ms |  3.2330 ms |  2800.0000 |  17.14 MB |
| EncodeNestedDict |       8 |       16 | 138.955 ms | 11.0044 ms |  7.2787 ms |  5500.0000 |  33.28 MB |
|       EncodeList |      16 |        8 |   7.396 ms |  0.7947 ms |  0.5257 ms |   398.4375 |   2.42 MB |
|       EncodeDict |      16 |        8 |  27.286 ms |  1.7213 ms |  1.1385 ms |   718.7500 |   4.33 MB |
| EncodeNestedList |      16 |        8 | 108.680 ms |  4.5182 ms |  2.9885 ms |  5800.0000 |   35.3 MB |
| EncodeNestedDict |      16 |        8 | 471.722 ms |  9.6321 ms |  6.3710 ms | 11000.0000 |  67.73 MB |
|       EncodeList |      16 |       16 |   7.570 ms |  0.1171 ms |  0.0775 ms |   632.8125 |    3.8 MB |
|       EncodeDict |      16 |       16 |  27.453 ms |  0.9822 ms |  0.6496 ms |  1156.2500 |   7.07 MB |
| EncodeNestedList |      16 |       16 | 114.874 ms |  4.2063 ms |  2.7822 ms |  9400.0000 |  57.27 MB |
| EncodeNestedDict |      16 |       16 | 462.164 ms | 56.9407 ms | 37.6628 ms | 18000.0000 | 113.04 MB |