### PR TITLE
Remove improperly supported "unbounded" size

### DIFF
--- a/Bencodex.Tests/EncoderTest.cs
+++ b/Bencodex.Tests/EncoderTest.cs
@@ -30,9 +30,9 @@ namespace Bencodex.Tests
         public void EncodeNull()
         {
             var buffer = new byte[10];
-            long offset = 3L;
+            int offset = 3;
             Encoder.EncodeNull(buffer, ref offset);
-            Assert.Equal(3L + 1L, offset);
+            Assert.Equal(3 + 1, offset);
             AssertEqual(new byte[] { 0, 0, 0, 0x6e, 0, 0, 0, 0, 0, 0 }, buffer);
         }
 
@@ -40,14 +40,14 @@ namespace Bencodex.Tests
         public void EncodeBoolean()
         {
             var buffer = new byte[10];
-            long offset = 2L;
+            int offset = 2;
             Encoder.EncodeBoolean(new Boolean(true), buffer, ref offset);
-            Assert.Equal(2L + 1L, offset);
+            Assert.Equal(2 + 1, offset);
             AssertEqual(new byte[] { 0, 0, 0x74, 0, 0, 0, 0, 0, 0, 0 }, buffer);
 
-            offset = 5L;
+            offset = 5;
             Encoder.EncodeBoolean(new Boolean(false), buffer, ref offset);
-            Assert.Equal(5L + 1L, offset);
+            Assert.Equal(5 + 1, offset);
             AssertEqual(new byte[] { 0, 0, 0x74, 0, 0, 0x66, 0, 0, 0, 0 }, buffer);
         }
 
@@ -55,21 +55,21 @@ namespace Bencodex.Tests
         public void EncodeInteger()
         {
             var buffer = new byte[10];
-            long offset = 2L;
+            int offset = 2;
             Encoder.EncodeInteger(0, buffer, ref offset);
-            Assert.Equal(2L + 3L, offset);
+            Assert.Equal(2 + 3, offset);
             AssertEqual(new byte[] { 0, 0, 0x69, 0x30, 0x65, 0, 0, 0, 0, 0 }, buffer);
 
             Clear(buffer, 0, buffer.Length);
-            offset = 1L;
+            offset = 1;
             Encoder.EncodeInteger(-123, buffer, ref offset);
-            Assert.Equal(1L + 6L, offset);
+            Assert.Equal(1 + 6, offset);
             AssertEqual(new byte[] { 0, 0x69, 0x2d, 0x31, 0x32, 0x33, 0x65, 0, 0, 0 }, buffer);
 
             Clear(buffer, 0, buffer.Length);
-            offset = 4L;
+            offset = 4;
             Encoder.EncodeInteger(456, buffer, ref offset);
-            Assert.Equal(4L + 5L, offset);
+            Assert.Equal(4 + 5, offset);
             AssertEqual(new byte[] { 0, 0, 0, 0, 0x69, 0x34, 0x35, 0x36, 0x65, 0 }, buffer);
         }
 
@@ -77,9 +77,9 @@ namespace Bencodex.Tests
         public void EncodeBinary()
         {
             var buffer = new byte[20];
-            long offset = 2L;
+            int offset = 2;
             Encoder.EncodeBinary(new Binary("hello world", Encoding.ASCII), buffer, ref offset);
-            Assert.Equal(2L + 14L, offset);
+            Assert.Equal(2 + 14, offset);
             AssertEqual(
                 new byte[20]
                 {
@@ -97,9 +97,9 @@ namespace Bencodex.Tests
         public void EncodeText()
         {
             var buffer = new byte[20];
-            long offset = 5L;
+            int offset = 5;
             Encoder.EncodeText("한글", buffer, ref offset);
-            Assert.Equal(5L + 9L, offset);
+            Assert.Equal(5 + 9, offset);
             AssertEqual(
                 new byte[20]
                 {
@@ -115,7 +115,7 @@ namespace Bencodex.Tests
         [Fact]
         public void CountDecimalDigits()
         {
-            for (long i = 0; i <= 1000L; i++)
+            for (int i = 0; i <= 1000; i++)
             {
                 Assert.Equal(
                     i.ToString(CultureInfo.InvariantCulture).Length,
@@ -126,7 +126,7 @@ namespace Bencodex.Tests
             var random = new System.Random();
             for (int i = 0; i < 100; i++)
             {
-                long n = (long)random.Next(0, int.MaxValue);
+                int n = random.Next(0, int.MaxValue);
                 Assert.Equal(
                     n.ToString(CultureInfo.InvariantCulture).Length,
                     Encoder.CountDecimalDigits(n)
@@ -138,35 +138,35 @@ namespace Bencodex.Tests
         public void EncodeDigits()
         {
             var buffer = new byte[10];
-            long offset = 2L;
-            Encoder.EncodeDigits(0L, buffer, ref offset);
-            Assert.Equal(2L + 1L, offset);
+            int offset = 2;
+            Encoder.EncodeDigits(0, buffer, ref offset);
+            Assert.Equal(2 + 1, offset);
             AssertEqual(new byte[] { 0, 0, 0x30, 0, 0, 0, 0, 0, 0, 0 }, buffer);
 
             Clear(buffer, 0, buffer.Length);
-            offset = 0L;
-            Encoder.EncodeDigits(5L, buffer, ref offset);
-            Assert.Equal(0L + 1L, offset);
+            offset = 0;
+            Encoder.EncodeDigits(5, buffer, ref offset);
+            Assert.Equal(0 + 1, offset);
             AssertEqual(new byte[] { 0x35, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, buffer);
 
             Clear(buffer, 0, buffer.Length);
-            offset = 5L;
-            Encoder.EncodeDigits(10L, buffer, ref offset);
-            Assert.Equal(5L + 2L, offset);
+            offset = 5;
+            Encoder.EncodeDigits(10, buffer, ref offset);
+            Assert.Equal(5 + 2, offset);
             AssertEqual(new byte[] { 0, 0, 0, 0, 0, 0x31, 0x30, 0, 0, 0 }, buffer);
 
             Clear(buffer, 0, buffer.Length);
-            offset = 6L;
-            Encoder.EncodeDigits(123L, buffer, ref offset);
-            Assert.Equal(6L + 3L, offset);
+            offset = 6;
+            Encoder.EncodeDigits(123, buffer, ref offset);
+            Assert.Equal(6 + 3, offset);
             AssertEqual(new byte[] { 0, 0, 0, 0, 0, 0, 0x31, 0x32, 0x33, 0 }, buffer);
 
             Clear(buffer, 0, buffer.Length);
-            offset = 0L;
-            Encoder.EncodeDigits(9876543210L, buffer, ref offset);
-            Assert.Equal(0L + 10L, offset);
+            offset = 0;
+            Encoder.EncodeDigits(987654321, buffer, ref offset);
+            Assert.Equal(0 + 9, offset);
             AssertEqual(
-                new byte[] { 0x39, 0x38, 0x37, 0x36, 0x35, 0x34, 0x33, 0x32, 0x31, 0x30 },
+                new byte[] { 0x39, 0x38, 0x37, 0x36, 0x35, 0x34, 0x33, 0x32, 0x31, 0 },
                 buffer
             );
         }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,9 +9,11 @@ To be released.
  -  Removed `Dictionary.GetValue<T>()` methods.  [[#122]]
  -  Optimized `Encoder.Encode()` method.  [[#124]]
  -  Fixed a bug in `Encoder.Encode(IValue, Stream)` method.  [[#124]]
+ -  Optimized `Encoder.Encode()` method.  [[#125]]
 
 [#122]: https://github.com/planetarium/bencodex.net/pull/122
 [#124]: https://github.com/planetarium/bencodex.net/pull/124
+[#125]: https://github.com/planetarium/bencodex.net/pull/125
 
 
 Version 0.16.0


### PR DESCRIPTION
This should follow #124.

Squeezes out another 5% or so from the result of #124. Although technically, unbounded encoding length could be considered as part of the spec, this would be hard to do properly without taking a significant performance hit. If one really wants to support it, the entire stack must be overhauled.

There are two rationales:
- I am skeptical of the original code that it actually supports the feature and works properly it is trying to accommodate.
  - C# itself has a hard limit on an array's length, which is `int.MaxValue`.
  - That is, one cannot expect `byte[]` to be of length greater than `int.MaxValue`. Especially `buffer[offset]` where `offset` is greater than `int.MaxValue` is likely to fail.
- With `int.MaxValue`, the maximum size of `byte[]` comes out to be about 2GB. For all intents and purposes, this should be enough for now for encoding a single `IValue`.
  - **Bencode**, which forms the basis of the bencodex, originates from encoding torrent metadata files, not the file itself. It was never meant to be big. 🙄

Note that serialization of `BigInteger`, i.e. an integer without a limit (as long as it doesn't exceed **`int.MaxValue` number of digits in length**), is still supported.

## `Encode()` without bloat

|           Method | SetSize | WordSize |       Mean |      Error |     StdDev |       Gen0 | Allocated |
|----------------- |-------- |--------- |-----------:|-----------:|-----------:|-----------:|----------:|
|       EncodeList |       8 |        8 |   3.200 ms |  0.3390 ms |  0.2243 ms |   265.6250 |    1.6 MB |
|       EncodeDict |       8 |        8 |  12.088 ms |  1.2449 ms |  0.8234 ms |   453.1250 |   2.73 MB |
| EncodeNestedList |       8 |        8 |  27.358 ms |  2.9628 ms |  1.9597 ms |  1937.5000 |  11.65 MB |
| EncodeNestedDict |       8 |        8 | 121.634 ms | 10.6371 ms |  5.5634 ms |  3500.0000 |   21.6 MB |
|       EncodeList |       8 |       16 |   3.773 ms |  0.5371 ms |  0.3553 ms |   382.8125 |   2.29 MB |
|       EncodeDict |       8 |       16 |  13.179 ms |  0.2856 ms |  0.1889 ms |   671.8750 |    4.1 MB |
| EncodeNestedList |       8 |       16 |  30.123 ms |  4.3146 ms |  2.8538 ms |  2812.5000 |  17.14 MB |
| EncodeNestedDict |       8 |       16 | 134.295 ms | 15.8120 ms | 10.4586 ms |  5500.0000 |  33.28 MB |
|       EncodeList |      16 |        8 |   6.171 ms |  0.8664 ms |  0.5730 ms |   398.4375 |   2.42 MB |
|       EncodeDict |      16 |        8 |  25.133 ms |  2.0928 ms |  1.3842 ms |   718.7500 |   4.33 MB |
| EncodeNestedList |      16 |        8 |  95.434 ms | 15.1526 ms | 10.0225 ms |  5833.3333 |   35.3 MB |
| EncodeNestedDict |      16 |        8 | 416.789 ms | 55.9215 ms | 36.9886 ms | 11000.0000 |  67.73 MB |
|       EncodeList |      16 |       16 |   6.843 ms |  1.0291 ms |  0.6807 ms |   632.8125 |    3.8 MB |
|       EncodeDict |      16 |       16 |  27.280 ms |  1.8400 ms |  1.0949 ms |  1156.2500 |   7.07 MB |
| EncodeNestedList |      16 |       16 | 109.229 ms | 17.3151 ms | 11.4529 ms |  9500.0000 |  57.27 MB |
| EncodeNestedDict |      16 |       16 | 447.549 ms | 44.9496 ms | 29.7314 ms | 18000.0000 | 113.04 MB |
